### PR TITLE
Implement main menu and new features

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Calculadora de Dias y de Fojas</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+</head>
+<body>
+  <div class="logo-container">
+    <img src="logo.png" alt="Logo Neuquén Capital" class="logo" />
+  </div>
+
+  <div class="container">
+<h1>Calculadora de Días y de Fojas</h1>
+
+<p class="subtitle">Hola! con la siguiente calculadora vamos a calcular la fecha de finalización de la obra y fojas a realizar.</p>
+<p class="warning">Si paralizás la obra con fecha posterior al inicio, debés generar una foja un día antes de la paralización.</p>
+
+    
+    <label>Fecha de inicio de obra:
+      <input type="date" id="startDate" />
+    </label>
+
+    <label>Plazo inicial (en días):
+      <input type="number" id="initialDays" />
+    </label>
+
+    <label>¿Hubo paralizaciones?
+      <select id="hasPauses">
+        <option value="no">No</option>
+        <option value="yes">Sí</option>
+      </select>
+    </label>
+
+    <div id="pauseSection"></div>
+
+    <label>¿Hubo ampliación de plazo?
+      <select id="hasExtension">
+        <option value="no">No</option>
+        <option value="yes">Sí</option>
+      </select>
+    </label>
+
+    <div id="extensionSection"></div>
+
+    <button id="calculateBtn" onclick="calculate()">Calcular</button>
+    <button onclick="clearAll()">Borrar todo</button>
+    <button onclick="shareWhatsApp()">Compartir por WhatsApp</button>
+
+    <div id="result"></div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,52 +1,19 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Calculadora de Dias y de Fojas</title>
-  <link rel="stylesheet" href="styles.css" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Certy App</title>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div class="logo-container">
-    <img src="logo.png" alt="Logo Neuquén Capital" class="logo" />
+    <img src="logo.png" alt="Logo Neuquén Capital" class="logo">
   </div>
-
-  <div class="container">
-<h1>Calculadora de Días y de Fojas</h1>
-<p class="subtitle">Hola! con la siguiente calculadora vamos a calcular la fecha de finalización de la obra y fojas a realizar.</p>
-
-    
-    <label>Fecha de inicio de obra:
-      <input type="date" id="startDate" />
-    </label>
-
-    <label>Plazo inicial (en días):
-      <input type="number" id="initialDays" />
-    </label>
-
-    <label>¿Hubo paralizaciones?
-      <select id="hasPauses">
-        <option value="no">No</option>
-        <option value="yes">Sí</option>
-      </select>
-    </label>
-
-    <div id="pauseSection"></div>
-
-    <label>¿Hubo ampliación de plazo?
-      <select id="hasExtension">
-        <option value="no">No</option>
-        <option value="yes">Sí</option>
-      </select>
-    </label>
-
-    <div id="extensionSection"></div>
-
-    <button onclick="calculate()">Calcular</button>
-
-    <div id="result"></div>
+  <div class="container menu">
+    <h1>Certy App</h1>
+    <button onclick="window.location.href='calculator.html'">Calculadora de Días y Fojas</button>
+    <button disabled>Próximamente más funciones</button>
   </div>
-
-  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -153,6 +153,9 @@ function calculate() {
       currentDate = addDays(currentDate, diff);
       resultHTML += `<p><strong>Finalización tras Paralización ${i + 1}:</strong> ${formatDate(currentDate)}</p>`;
     });
+    if (pauses.some(([pStart]) => pStart > startDate)) {
+      alert('Si paraliza la obra con fecha posterior al inicio, genere una foja un día antes de la paralización.');
+    }
   }
 
   if (hasExtension) {
@@ -167,6 +170,32 @@ function calculate() {
 
   document.getElementById("result").innerHTML = resultHTML;
 }
+
+function clearAll() {
+  document.getElementById('startDate').value = '';
+  document.getElementById('initialDays').value = '';
+  document.getElementById('hasPauses').value = 'no';
+  document.getElementById('hasExtension').value = 'no';
+  document.getElementById('pauseSection').innerHTML = '';
+  document.getElementById('extensionSection').innerHTML = '';
+  document.getElementById('result').innerHTML = '';
+}
+
+function shareWhatsApp() {
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF();
+  const result = document.getElementById('result').innerText || 'Sin resultados';
+  doc.text(result, 10, 10);
+  const pdfBlob = doc.output('blob');
+  const url = URL.createObjectURL(pdfBlob);
+  window.open(url);
+  window.open('https://api.whatsapp.com/send?text=' + encodeURIComponent('Te envio los resultados en PDF. Descarga el archivo abierto y compartelo.'), '_blank');
+}
+
+document.getElementById('calculateBtn').addEventListener('click', function() {
+  this.classList.add('robot');
+  setTimeout(() => this.classList.remove('robot'), 300);
+});
 
 document.getElementById("hasPauses").addEventListener("change", function () {
   const section = document.getElementById("pauseSection");

--- a/styles.css
+++ b/styles.css
@@ -81,3 +81,39 @@ button:hover {
   transform: scale(1.05);
 }
 
+.warning {
+  background: #ffd166;
+  color: #1b1b1b;
+  padding: 0.5rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+@keyframes robotMove {
+  0% { transform: translateX(0); }
+  25% { transform: translateX(-2px); }
+  50% { transform: translateX(2px); }
+  75% { transform: translateX(-2px); }
+ 100% { transform: translateX(0); }
+}
+
+.robot {
+  animation: robotMove 0.3s linear;
+}
+
+.menu button {
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .container {
+    width: 95%;
+    margin: 1rem auto;
+    padding: 1rem;
+  }
+  button {
+    width: 100%;
+  }
+}
+


### PR DESCRIPTION
## Summary
- create a menu page that links to the calculator
- move previous calculator content into `calculator.html`
- warn about foja generation when a pause starts after the work start date
- add clear button, robotic animation and WhatsApp sharing
- make layout responsive for mobile

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688031256550832e9ce39bdb276c219c