### PR TITLE
Implement main menu and calculator improvements

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Calculadora de Dias y de Fojas</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+</head>
+<body>
+  <div class="logo-container">
+    <img src="logo.png" alt="Logo Neuquén Capital" class="logo" />
+  </div>
+
+  <div class="container">
+    <button class="backBtn" onclick="window.location.href='index.html'">Volver al menú</button>
+<h1>Calculadora de Días y de Fojas</h1>
+
+<p class="subtitle">Hola! con la siguiente calculadora vamos a calcular la fecha de finalización de la obra y fojas a realizar.</p>
+<p id="warning" class="warning" style="display:none;">Si paralizás la obra con fecha posterior al inicio, debés generar una foja un día antes de la paralización.</p>
+
+    
+    <label>Fecha de inicio de obra:
+      <input type="date" id="startDate" placeholder="Ingrese fecha" />
+    </label>
+
+    <label>Plazo inicial (en días):
+      <input type="number" id="initialDays" placeholder="Cantidad" />
+    </label>
+
+    <label>¿Hubo paralizaciones?
+      <select id="hasPauses">
+        <option value="no">No</option>
+        <option value="yes">Sí</option>
+      </select>
+    </label>
+
+    <div id="pauseSection"></div>
+
+    <label>¿Hubo ampliación de plazo?
+      <select id="hasExtension">
+        <option value="no">No</option>
+        <option value="yes">Sí</option>
+      </select>
+    </label>
+
+    <div id="extensionSection"></div>
+
+    <div class="button-row">
+      <button id="calculateBtn" onclick="calculate()">Calcular</button>
+      <button onclick="clearAll()">Borrar todo</button>
+    </div>
+
+    <div id="result"></div>
+    <button id="shareBtn" onclick="shareWhatsApp()" style="display:none;">Compartir por WhatsApp</button>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,52 +1,21 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Calculadora de Dias y de Fojas</title>
-  <link rel="stylesheet" href="styles.css" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Certy App</title>
+  <link rel="stylesheet" href="styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 </head>
 <body>
   <div class="logo-container">
-    <img src="logo.png" alt="Logo Neuquén Capital" class="logo" />
+    <img src="logo.png" alt="Logo Neuquén Capital" class="logo">
   </div>
-
-  <div class="container">
-<h1>Calculadora de Días y de Fojas</h1>
-<p class="subtitle">Hola! con la siguiente calculadora vamos a calcular la fecha de finalización de la obra y fojas a realizar.</p>
-
-    
-    <label>Fecha de inicio de obra:
-      <input type="date" id="startDate" />
-    </label>
-
-    <label>Plazo inicial (en días):
-      <input type="number" id="initialDays" />
-    </label>
-
-    <label>¿Hubo paralizaciones?
-      <select id="hasPauses">
-        <option value="no">No</option>
-        <option value="yes">Sí</option>
-      </select>
-    </label>
-
-    <div id="pauseSection"></div>
-
-    <label>¿Hubo ampliación de plazo?
-      <select id="hasExtension">
-        <option value="no">No</option>
-        <option value="yes">Sí</option>
-      </select>
-    </label>
-
-    <div id="extensionSection"></div>
-
-    <button onclick="calculate()">Calcular</button>
-
-    <div id="result"></div>
+    <div class="container menu">
+      <h1 class="pixel">¡Hola! Soy Certy, ¿Qué vamos a hacer hoy?</h1>
+      <p class="subtitle">Seleccioná una opción para continuar</p>
+      <button onclick="window.location.href='calculator.html'">Calculadora de Días y Fojas</button>
+      <button disabled>Próximamente más funciones</button>
   </div>
-
-  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -83,6 +83,7 @@ function generarTablaFojas(startDate, endDate, pauses = []) {
   });
 
   let tablaHTML = `
+    <div class="fojas-box">
     <h3>Detalle de Fojas</h3>
     <table border="1" cellpadding="8" cellspacing="0" style="width:100%; border-collapse: collapse; background: white; color: black; margin-top: 1rem;">
       <thead>
@@ -105,7 +106,7 @@ function generarTablaFojas(startDate, endDate, pauses = []) {
     `;
   });
 
-  tablaHTML += `</tbody></table>`;
+  tablaHTML += `</tbody></table></div>`;
   return tablaHTML;
 }
 
@@ -147,12 +148,18 @@ function calculate() {
 
   let resultHTML = `<p><strong>Fecha de finalización inicial:</strong> ${formatDate(currentDate)}</p>`;
 
+  const warningEl = document.getElementById('warning');
+  warningEl.style.display = 'none';
+
   if (hasPauses) {
     pauses.forEach(([pauseStart, pauseEnd], i) => {
       const diff = Math.round((pauseEnd - pauseStart) / (1000 * 60 * 60 * 24)) + 1;
       currentDate = addDays(currentDate, diff);
       resultHTML += `<p><strong>Finalización tras Paralización ${i + 1}:</strong> ${formatDate(currentDate)}</p>`;
     });
+    if (pauses.some(([pStart]) => pStart > startDate)) {
+      warningEl.style.display = 'block';
+    }
   }
 
   if (hasExtension) {
@@ -166,7 +173,43 @@ function calculate() {
   resultHTML += generarTablaFojas(startDate, currentDate, pauses);
 
   document.getElementById("result").innerHTML = resultHTML;
+  document.getElementById('shareBtn').style.display = 'block';
 }
+
+function clearAll() {
+  document.getElementById('startDate').value = '';
+  document.getElementById('initialDays').value = '';
+  document.getElementById('hasPauses').value = 'no';
+  document.getElementById('hasExtension').value = 'no';
+  document.getElementById('pauseSection').innerHTML = '';
+  document.getElementById('extensionSection').innerHTML = '';
+  document.getElementById('result').innerHTML = '';
+  document.getElementById('warning').style.display = 'none';
+  document.getElementById('shareBtn').style.display = 'none';
+}
+
+function shareWhatsApp() {
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF({ unit: 'pt', format: 'a4' });
+  const resultEl = document.getElementById('result');
+  doc.html(resultEl, {
+    margin: [40, 40, 60, 40],
+    callback: function (doc) {
+      const pageH = doc.internal.pageSize.height || doc.internal.pageSize.getHeight();
+      doc.setFontSize(10);
+      doc.text('Gracias por usar la app de Certy!', 40, pageH - 20);
+      const pdfBlob = doc.output('blob');
+      const url = URL.createObjectURL(pdfBlob);
+      window.open(url);
+      window.open('https://api.whatsapp.com/send?text=' + encodeURIComponent('Te envio los resultados en PDF. Descarga el archivo abierto y compartelo.'), '_blank');
+    }
+  });
+}
+
+document.getElementById('calculateBtn').addEventListener('click', function() {
+  this.classList.add('robot');
+  setTimeout(() => this.classList.remove('robot'), 300);
+});
 
 document.getElementById("hasPauses").addEventListener("change", function () {
   const section = document.getElementById("pauseSection");
@@ -189,8 +232,8 @@ document.getElementById("hasPauses").addEventListener("change", function () {
       for (let i = 1; i <= count; i++) {
         container.innerHTML += `
           <div class="pauseGroup">
-            <label>Inicio de Paralización ${i}: <input type="date" class="pauseStart" /></label>
-            <label>Fin de Paralización ${i}: <input type="date" class="pauseEnd" /></label>
+            <label>Inicio de Paralización ${i}: <input type="date" class="pauseStart" placeholder="Inicio" /></label>
+            <label>Fin de Paralización ${i}: <input type="date" class="pauseEnd" placeholder="Fin" /></label>
           </div>
         `;
       }
@@ -207,7 +250,7 @@ document.getElementById("hasExtension").addEventListener("change", function () {
 
   if (this.value === "yes") {
     section.innerHTML = `
-      <label>Ampliación de plazo (en días): <input type="number" id="extensionDays" /></label>
+      <label>Ampliación de plazo (en días): <input type="number" id="extensionDays" placeholder="Cantidad" /></label>
     `;
   }
 });

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
 
 body {
   font-family: 'Inter', sans-serif;
@@ -35,6 +36,12 @@ h1 {
   text-align: center;
   font-size: 2rem;
   margin-bottom: 0.5rem;
+}
+
+.pixel {
+  font-family: 'Press Start 2P', cursive;
+  font-size: 1rem;
+  color: #00f7ff;
 }
 
 .subtitle {
@@ -79,5 +86,88 @@ button {
 button:hover {
   background-color: #d90429;
   transform: scale(1.05);
+}
+
+.button-row {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.button-row button {
+  margin: 2rem 0 0 0;
+}
+
+.backBtn {
+  background: transparent;
+  color: #fff;
+  border: 1px solid #fff;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.backBtn:hover {
+  background: rgba(255,255,255,0.1);
+}
+
+#shareBtn {
+  background-color: #25D366;
+  margin-top: 2rem;
+  margin-bottom: 4rem;
+}
+
+.fojas-box {
+  border: 2px solid #ffffff;
+  padding: 1rem;
+  border-radius: 10px;
+  margin-top: 1rem;
+}
+
+.warning {
+  background: #ffd166;
+  color: #1b1b1b;
+  padding: 0.5rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+@keyframes robotMove {
+  0% { transform: translateX(0); }
+  25% { transform: translateX(-2px); }
+  50% { transform: translateX(2px); }
+  75% { transform: translateX(-2px); }
+ 100% { transform: translateX(0); }
+}
+
+.robot {
+  animation: robotMove 0.3s linear;
+}
+
+.menu {
+  text-align: center;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 2rem;
+  border-radius: 15px;
+  box-shadow: 0 0 15px rgba(0,255,255,0.4);
+}
+
+.menu button {
+  width: 100%;
+  background-color: #1b9aaa;
+  box-shadow: 0 0 10px rgba(0,255,255,0.7);
+}
+
+@media (max-width: 600px) {
+  .container {
+    width: 95%;
+    margin: 1rem auto;
+    padding: 1rem;
+  }
+  button {
+    width: 100%;
+  }
 }
 


### PR DESCRIPTION
## Summary
- restyle main menu with pixel font greeting
- show pause warning only when needed
- align calculate and clear buttons
- add green WhatsApp share button at bottom
- create nicer PDF output with footer
- add back button and hide share until results
- minor UX tweaks like placeholders

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688031256550832e9ce39bdb276c219c