### PR TITLE
Implement share PDF via WhatsApp example

### DIFF
--- a/AndroidApp/app/src/main/AndroidManifest.xml
+++ b/AndroidApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.certyapp">
+
+    <application
+        android:allowBackup="true"
+        android:label="CertyApp"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.CertyApp">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
+    </application>
+</manifest>

--- a/AndroidApp/app/src/main/java/com/example/certyapp/MainActivity.java
+++ b/AndroidApp/app/src/main/java/com/example/certyapp/MainActivity.java
@@ -1,0 +1,100 @@
+package com.example.certyapp;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.pdf.PdfDocument;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Environment;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.core.content.FileProvider;
+import android.view.View;
+import android.widget.Button;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class MainActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        Button shareButton = findViewById(R.id.shareButton);
+        shareButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                try {
+                    File pdfFile = generatePdf();
+                    sharePdf(pdfFile);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    private File generatePdf() throws IOException {
+        String fileName = "Reporte" + System.currentTimeMillis() + ".pdf";
+        File pdfDir = new File(getFilesDir(), "pdfs");
+        if (!pdfDir.exists()) {
+            pdfDir.mkdirs();
+        }
+        File pdfFile = new File(pdfDir, fileName);
+
+        PdfDocument document = new PdfDocument();
+        PdfDocument.PageInfo pageInfo = new PdfDocument.PageInfo.Builder(300, 300, 1).create();
+        PdfDocument.Page page = document.startPage(pageInfo);
+        Canvas canvas = page.getCanvas();
+        Paint paint = new Paint();
+        paint.setTextSize(16);
+        canvas.drawText("Contenido del reporte", 50, 50, paint);
+        document.finishPage(page);
+
+        FileOutputStream fos = new FileOutputStream(pdfFile);
+        document.writeTo(fos);
+        document.close();
+        fos.close();
+
+        return pdfFile;
+    }
+
+    private void sharePdf(File pdfFile) {
+        Context context = this;
+        Uri uri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", pdfFile);
+
+        Intent shareIntent = new Intent(Intent.ACTION_SEND);
+        shareIntent.setType("application/pdf");
+        shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+        // Check if WhatsApp is installed
+        PackageManager pm = getPackageManager();
+        boolean hasWhatsApp;
+        try {
+            pm.getPackageInfo("com.whatsapp", PackageManager.GET_ACTIVITIES);
+            hasWhatsApp = true;
+        } catch (PackageManager.NameNotFoundException e) {
+            hasWhatsApp = false;
+        }
+
+        Intent chooser;
+        if (hasWhatsApp) {
+            Intent whatsappIntent = new Intent(shareIntent);
+            whatsappIntent.setPackage("com.whatsapp");
+            chooser = Intent.createChooser(whatsappIntent, "Compartir PDF");
+            chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] { shareIntent });
+        } else {
+            chooser = Intent.createChooser(shareIntent, "Compartir PDF");
+        }
+
+        startActivity(chooser);
+    }
+}
+

--- a/AndroidApp/app/src/main/res/layout/activity_main.xml
+++ b/AndroidApp/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/shareButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Compartir por WhatsApp" />
+</LinearLayout>

--- a/AndroidApp/app/src/main/res/values/styles.xml
+++ b/AndroidApp/app/src/main/res/values/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.CertyApp" parent="Theme.AppCompat.Light.NoActionBar" />
+</resources>

--- a/AndroidApp/app/src/main/res/xml/provider_paths.xml
+++ b/AndroidApp/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path
+        name="pdfs"
+        path="pdfs/" />
+</paths>


### PR DESCRIPTION
## Summary
- add example Android project that exports a PDF
- configure FileProvider in manifest and provider_paths
- implement MainActivity to generate PDF and share via WhatsApp
- include basic layout and style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68805b2d31bc832eacf8306bfe128577