### PR TITLE
Add flatpickr for pause range selection

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -5,8 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Calculadora de Dias y de Fojas</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
 </head>
 <body>
   <div class="logo-container">

--- a/script.js
+++ b/script.js
@@ -124,12 +124,11 @@ function calculate() {
   if (hasPauses) {
     const pauseGroups = document.querySelectorAll(".pauseGroup");
     pauseGroups.forEach(group => {
-      const rawStart = group.querySelector(".pauseStart").value;
-      const rawEnd = group.querySelector(".pauseEnd").value;
-
-      if (!rawStart || !rawEnd) {
+      const rawRange = group.querySelector(".pauseRange").value;
+      if (!rawRange || !rawRange.includes(" a ")) {
         return;
       }
+      const [rawStart, rawEnd] = rawRange.split(" a ");
 
       const [sY, sM, sD] = rawStart.split("-").map(Number);
       const [eY, eM, eD] = rawEnd.split("-").map(Number);
@@ -299,11 +298,19 @@ document.getElementById("hasPauses").addEventListener("change", function () {
       for (let i = 1; i <= count; i++) {
         container.innerHTML += `
           <div class="pauseGroup">
-            <label>Inicio de Paralización ${i}: <input type="date" class="pauseStart" placeholder="Inicio" /></label>
-            <label>Fin de Paralización ${i}: <input type="date" class="pauseEnd" placeholder="Fin" /></label>
-          </div>
-        `;
+            <label>Paralización ${i}:
+              <input type="text" class="pauseRange" placeholder="Seleccionar rango"/>
+            </label>
+          </div>`;
       }
+      container.querySelectorAll('.pauseRange').forEach(el => {
+        flatpickr(el, {
+          mode: 'range',
+          dateFormat: 'Y-m-d',
+          locale: 'es',
+          rangeSeparator: ' a '
+        });
+      });
     }
 
     pauseCountInput.addEventListener("input", renderPauseInputs);


### PR DESCRIPTION
## Summary
- load flatpickr in `calculator.html`
- generate pause ranges with a single input and enable date range picker
- parse pause ranges during calculation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68853863e6fc832ea4e4e2507fb729cd