### PR TITLE
Implement sepia theme and Certy chatbot

### DIFF
--- a/chatbot.js
+++ b/chatbot.js
@@ -1,0 +1,53 @@
+let bibliographyText = '';
+
+async function loadBibliografia() {
+  try {
+    const pdfUrl = encodeURI('Bibliografia/Ley Nº 687-1972 Ley de Obra Pública y Decreto Nº 108-1972.pdf');
+    const pdf = await pdfjsLib.getDocument(pdfUrl).promise;
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const page = await pdf.getPage(i);
+      const text = await page.getTextContent();
+      bibliographyText += text.items.map(t => t.str).join(' ') + ' ';
+    }
+  } catch (e) { console.error(e); }
+  try {
+    const docUrl = encodeURI('Bibliografia/Manual Práctico para Gestionar Alteraciones Contractuales en Obras Públicas.docx');
+    const resp = await fetch(docUrl);
+    const arrayBuffer = await resp.arrayBuffer();
+    const result = await mammoth.extractRawText({arrayBuffer});
+    bibliographyText += result.value + ' ';
+  } catch (e) { console.error(e); }
+  bibliographyText = bibliographyText.toLowerCase();
+}
+
+function searchBibliography(query) {
+  query = query.toLowerCase();
+  if (bibliographyText.includes(query)) {
+    const idx = bibliographyText.indexOf(query);
+    return bibliographyText.slice(Math.max(0, idx - 60), Math.min(bibliographyText.length, idx + query.length + 60)) + '...';
+  }
+  return 'Esta información no está en la bibliografía. Por favor, consulte al Director General de Certificaciones.';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadBibliografia();
+  const toggle = document.getElementById('chatbotToggle');
+  const win = document.getElementById('chatbotWindow');
+  const input = document.getElementById('chatInput');
+  const send = document.getElementById('chatSend');
+  const content = document.getElementById('chatContent');
+
+  toggle.addEventListener('click', () => {
+    win.classList.toggle('show');
+  });
+
+  send.addEventListener('click', () => {
+    const q = input.value.trim();
+    if (!q) return;
+    content.innerHTML += `<div><strong>Tú:</strong> ${q}</div>`;
+    const ans = searchBibliography(q);
+    content.innerHTML += `<div><strong>Certy:</strong> ${ans}</div>`;
+    input.value = '';
+    content.scrollTop = content.scrollHeight;
+  });
+});

--- a/common.js
+++ b/common.js
@@ -1,4 +1,4 @@
-// Theme toggle and robot interaction
+// Theme toggle and shared actions
 
 document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.getElementById('themeToggle');
@@ -16,41 +16,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const robot = document.getElementById('robot');
-  const audio = document.getElementById('robotSound');
-  if (robot) {
-    const wave = () => {
-      robot.classList.add('wave');
-      if (audio) {
-        audio.currentTime = 0;
-        audio.play();
-      }
-      setTimeout(() => robot.classList.remove('wave'), 1000);
-    };
-
-    const start = () => {
-      robot.classList.add('enter');
-      setTimeout(wave, 1500);
-      setTimeout(() => robot.classList.add('exit'), 3000);
-      setTimeout(() => robot.classList.remove('enter', 'exit'), 5000);
-    };
-
-    const randomPeek = () => {
-      const side = Math.random() > 0.5 ? 'left' : 'right';
-      robot.classList.add(`peek-${side}`);
-      wave();
-      setTimeout(() => robot.classList.remove(`peek-${side}`), 3000);
-    };
-
-    let idleTimer;
-    const resetIdle = () => {
-      clearTimeout(idleTimer);
-      idleTimer = setTimeout(randomPeek, 10000);
-    };
-    document.addEventListener('mousemove', resetIdle);
-    document.addEventListener('keydown', resetIdle);
-    resetIdle();
-
-    start();
-  }
 });
+
+function installApp() {
+  document.body.classList.add('big-text');
+  window.open('https://lucerodamian88.github.io/Certy_app/download.html', '_blank');
+}

--- a/index.html
+++ b/index.html
@@ -9,8 +9,6 @@
 </head>
 <body>
   <button id="themeToggle">🌙</button>
-  <audio id="robotSound" src="https://assets.mixkit.co/sfx/preview/mixkit-robot-style-beep-1008.mp3"></audio>
-  <img id="robot" src="Robot.png" alt="Robot" />
   <div class="logo-container">
     <img src="logo.png" alt="Logo Neuquén Capital" class="logo">
   </div>
@@ -20,7 +18,15 @@
       <button onclick="window.location.href='calculator.html'">Calculadora de Días y Fojas</button>
       <button disabled>Próximamente más funciones</button>
 </div>
-<button id="downloadAppBtn" onclick="window.open('https://lucerodamian88.github.io/Certy_app/download.html', '_blank')">
+<div id="chatbot">
+  <button id="chatbotToggle"><img src="Robot.png" alt="Certy" width="40"></button>
+  <div id="chatbotWindow" class="hidden">
+    <div id="chatContent"></div>
+    <input type="text" id="chatInput" placeholder="Escribe tu pregunta">
+    <button id="chatSend">Enviar</button>
+  </div>
+</div>
+<button id="downloadAppBtn" onclick="installApp()">
   DESCARGAR CERTY EN TU CELULAR!<br><em>Sólo válido para Android</em>
 </button>
 <script>
@@ -33,5 +39,8 @@
   });
 </script>
 <script src="common.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.4.9/mammoth.browser.min.js"></script>
+<script src="chatbot.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -309,8 +309,8 @@ function shareWhatsApp() {
 }
 
 document.getElementById('calculateBtn').addEventListener('click', function() {
-  this.classList.add('robot');
-  setTimeout(() => this.classList.remove('robot'), 300);
+  this.classList.add('shake');
+  setTimeout(() => this.classList.remove('shake'), 300);
 });
 
 document.getElementById("hasPauses").addEventListener("change", function () {

--- a/styles.css
+++ b/styles.css
@@ -9,9 +9,13 @@ body {
   padding: 140px 0 120px 0; /* espacio para el banner fijo */
 }
 
+body.big-text {
+  font-size: 1.3rem;
+}
+
 body.light-mode {
-  background: linear-gradient(to right, #f0f0f0, #d9d9d9);
-  color: #1b1b1b;
+  background: linear-gradient(to right, #f4ecd8, #e7dec2);
+  color: #000000;
 }
 
 
@@ -27,7 +31,7 @@ body.light-mode {
 }
 
 body.light-mode .logo-container {
-  background: #ffffff;
+  background: #f5e8c7;
 }
 
 .logo {
@@ -75,6 +79,10 @@ h1 {
   max-width: 100%; /* Ensure it doesn't overflow container */
 }
 
+body.light-mode .pixel {
+  color: #000;
+}
+
 .cursor {
   display: inline-block;
   animation: blink 1s steps(2, start) infinite;
@@ -103,6 +111,10 @@ h1 {
   font-style: italic;
   color: #d3d3d3;
   margin-bottom: 2rem;
+}
+
+body.light-mode .subtitle {
+  color: #000;
 }
 
 label {
@@ -207,17 +219,18 @@ body.light-mode .backBtn {
   letter-spacing: 0.05em;
 }
 
-@keyframes robotMove {
+@keyframes shake {
   0% { transform: translateX(0); }
   25% { transform: translateX(-2px); }
   50% { transform: translateX(2px); }
   75% { transform: translateX(-2px); }
- 100% { transform: translateX(0); }
+  100% { transform: translateX(0); }
 }
 
-.robot {
-  animation: robotMove 0.3s linear;
+.shake {
+  animation: shake 0.3s linear;
 }
+
 
 .menu {
   text-align: center;
@@ -277,70 +290,6 @@ body.light-mode #downloadAppBtn {
   to { transform: translateY(100px); opacity: 0; }
 }
 
-/* Robot animation */
-#robot {
-  position: fixed;
-  bottom: 20px;
-  left: -150px;
-  width: 120px;
-  z-index: 1050;
-  pointer-events: none;
-}
-
-#robot.enter {
-  animation: robotEnter 2s forwards;
-}
-
-#robot.exit {
-  animation: robotExit 2s forwards;
-}
-
-#robot.wave {
-  animation: robotWave 1s ease-in-out;
-}
-
-#robot.peek-left {
-  right: auto;
-  left: -150px;
-  animation: robotPeekLeft 3s forwards;
-}
-
-#robot.peek-right {
-  left: auto;
-  right: -150px;
-  animation: robotPeekRight 3s forwards;
-}
-
-@keyframes robotEnter {
-  from { left: -150px; }
-  50% { left: calc(50% - 60px); }
-  to { left: calc(50% - 60px); }
-}
-
-@keyframes robotExit {
-  from { left: calc(50% - 60px); }
-  to { left: 110%; }
-}
-
-@keyframes robotWave {
-  0% { transform: rotate(0deg); }
-  50% { transform: rotate(10deg); }
-  100% { transform: rotate(0deg); }
-}
-
-@keyframes robotPeekLeft {
-  0% { left: -150px; }
-  30% { left: 0; }
-  70% { left: 0; }
-  100% { left: -150px; }
-}
-
-@keyframes robotPeekRight {
-  0% { right: -150px; }
-  30% { right: 0; }
-  70% { right: 0; }
-  100% { right: -150px; }
-}
 
 @media (max-width: 600px) {
   body {
@@ -362,5 +311,54 @@ body.light-mode #downloadAppBtn {
   #downloadAppBtn {
     width: auto;
   }
+}
+
+#chatbotToggle {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  z-index: 1200;
+}
+
+#chatbotWindow {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  width: 260px;
+  max-height: 400px;
+  background: rgba(0, 0, 0, 0.9);
+  color: #fff;
+  border-radius: 10px;
+  padding: 10px;
+  display: none;
+  flex-direction: column;
+  z-index: 1200;
+}
+
+body.light-mode #chatbotWindow {
+  background: #f5e8c7;
+  color: #000;
+}
+
+#chatContent {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 8px;
+}
+
+#chatbotWindow.show {
+  display: flex;
+}
+
+#chatbotWindow input {
+  width: 100%;
+  margin-bottom: 5px;
+}
+
+#chatbotWindow button {
+  width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- remove robot animation and references
- enlarge text when installing app
- overhaul light mode to sepia tones with black text
- add floating chatbot using Robot.png icon
- include shake animation for calculate button

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688570e6824c832e930d09553bade636