### PR TITLE
Reemplaza botón de WhatsApp con impresión de PDF

### DIFF
--- a/AndroidApp/app/src/main/java/com/example/certyapp/MainActivity.java
+++ b/AndroidApp/app/src/main/java/com/example/certyapp/MainActivity.java
@@ -1,17 +1,13 @@
 package com.example.certyapp;
 
-import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.pdf.PdfDocument;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Environment;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import android.view.View;
 import android.widget.Button;
@@ -26,13 +22,13 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        Button shareButton = findViewById(R.id.shareButton);
-        shareButton.setOnClickListener(new View.OnClickListener() {
+        Button printButton = findViewById(R.id.printButton);
+        printButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 try {
                     File pdfFile = generatePdf();
-                    sharePdf(pdfFile);
+                    openPdf(pdfFile);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -65,36 +61,13 @@ public class MainActivity extends AppCompatActivity {
         return pdfFile;
     }
 
-    private void sharePdf(File pdfFile) {
+    private void openPdf(File pdfFile) {
         Context context = this;
         Uri uri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", pdfFile);
-
-        Intent shareIntent = new Intent(Intent.ACTION_SEND);
-        shareIntent.setType("application/pdf");
-        shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
-        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-        // Check if WhatsApp is installed
-        PackageManager pm = getPackageManager();
-        boolean hasWhatsApp;
-        try {
-            pm.getPackageInfo("com.whatsapp", PackageManager.GET_ACTIVITIES);
-            hasWhatsApp = true;
-        } catch (PackageManager.NameNotFoundException e) {
-            hasWhatsApp = false;
-        }
-
-        Intent chooser;
-        if (hasWhatsApp) {
-            Intent whatsappIntent = new Intent(shareIntent);
-            whatsappIntent.setPackage("com.whatsapp");
-            chooser = Intent.createChooser(whatsappIntent, "Compartir PDF");
-            chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] { shareIntent });
-        } else {
-            chooser = Intent.createChooser(shareIntent, "Compartir PDF");
-        }
-
-        startActivity(chooser);
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setDataAndType(uri, "application/pdf");
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        startActivity(intent);
     }
 }
 

--- a/AndroidApp/app/src/main/res/layout/activity_main.xml
+++ b/AndroidApp/app/src/main/res/layout/activity_main.xml
@@ -7,8 +7,8 @@
     android:padding="16dp">
 
     <Button
-        android:id="@+id/shareButton"
+        android:id="@+id/printButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Compartir por WhatsApp" />
+        android:text="Imprimir informe en PDF" />
 </LinearLayout>

--- a/calculator.html
+++ b/calculator.html
@@ -57,7 +57,7 @@
     </div>
 
     <div id="result"></div>
-    <button id="shareBtn" onclick="shareWhatsApp()" style="display:none;">Compartir por WhatsApp</button>
+    <button id="printBtn" onclick="openPdfReport()" style="display:none;">Imprimir informe en PDF</button>
   </div>
 
   <script src="common.js"></script>

--- a/script.js
+++ b/script.js
@@ -233,7 +233,7 @@ function calculate() {
   resultHTML += generarTablaFojas(startDate, currentDate, pauses);
 
   document.getElementById("result").innerHTML = resultHTML;
-  document.getElementById('shareBtn').style.display = 'block';
+    document.getElementById('printBtn').style.display = 'block';
 }
 
 function clearAll() {
@@ -244,14 +244,14 @@ function clearAll() {
   document.getElementById('pauseSection').innerHTML = '';
   document.getElementById('extensionSection').innerHTML = '';
   document.getElementById('result').innerHTML = '';
-  document.getElementById('shareBtn').style.display = 'none';
+    document.getElementById('printBtn').style.display = 'none';
 }
 
-function shareWhatsApp() {
+function openPdfReport() {
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
   const resultEl = document.getElementById('result');
-  
+
   // Save original styles
   const originalStyles = {};
   const elements = resultEl.getElementsByTagName('*');
@@ -266,10 +266,10 @@ function shareWhatsApp() {
       el.style.backgroundColor = '#FFFFFF';
     }
   }
-  
+
   doc.html(resultEl, {
     margin: [40, 40, 60, 40],
-    html2canvas: { 
+    html2canvas: {
       scale: 0.8,
       logging: true,
       useCORS: true
@@ -279,7 +279,7 @@ function shareWhatsApp() {
       doc.setFontSize(10);
       doc.setTextColor(0, 0, 0); // Black text
       doc.text('Gracias por usar la app de Certy!', 40, pageH - 20);
-      
+
       // Restore original styles
       for (let el in originalStyles) {
         if (el.style) {
@@ -287,23 +287,10 @@ function shareWhatsApp() {
           el.style.backgroundColor = originalStyles[el].backgroundColor;
         }
       }
-      
+
       const pdfBlob = doc.output('blob');
-      const file = new File([pdfBlob], 'reporte.pdf', { type: 'application/pdf' });
-
-      const text = 'Te envío los resultados en PDF.';
-      if (navigator.share) {
-        navigator.share({ files: [file], text }).catch(() => {
-          const url = URL.createObjectURL(pdfBlob);
-          window.open(url, '_blank');
-          window.open('https://api.whatsapp.com/send?text=' + encodeURIComponent(text), '_blank');
-        });
-      } else {
-        const url = URL.createObjectURL(pdfBlob);
-        window.open(url, '_blank');
-        window.open('https://api.whatsapp.com/send?text=' + encodeURIComponent(text), '_blank');
-      }
-
+      const url = URL.createObjectURL(pdfBlob);
+      window.open(url, '_blank');
     }
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -192,7 +192,7 @@ body.light-mode .backBtn {
   background: rgba(255,255,255,0.1);
 }
 
-#shareBtn {
+#printBtn {
   background-color: #25D366;
   margin-top: 2rem;
   margin-bottom: 4rem;


### PR DESCRIPTION
## Resumen
- Cambia el botón de compartir por WhatsApp por "Imprimir informe en PDF" y abre el reporte en una nueva pestaña.
- Ajusta estilos y lógica para el nuevo botón.
- Actualiza la app Android para mostrar el PDF en un visor externo.

## Pruebas
- `npm test` *(falla: Could not read package.json)*
- `./gradlew test` *(falla: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e1bed45f0832ebe3e2780bee733a5