### PR TITLE
feat: neon theme and updated PDF report

### DIFF
--- a/script.js
+++ b/script.js
@@ -96,10 +96,11 @@ function generarTablaFojas(startDate, endDate, pauses = []) {
       <tbody>
   `;
 
-  fojas.forEach(foja => {
+  fojas.forEach((foja, index) => {
+    const label = index === fojas.length - 1 ? `${foja.numero} FINAL` : `${foja.numero}`;
     tablaHTML += `
       <tr>
-        <td>${foja.numero}</td>
+        <td>${label}</td>
         <td>${foja.desde}</td>
         <td>${foja.hasta}</td>
       </tr>
@@ -177,7 +178,7 @@ function calculate() {
   const finalDate = addDays(startDate, initialDays - 1);
   let currentDate = new Date(finalDate);
 
-  let resultHTML = `<h2>REPORTE GENERADO POR CERTY</h2>`;
+  let resultHTML = `<h2 style="text-align: center; text-decoration: underline;">REPORTE GENERADO POR LA APP CERTY</h2>`;
   resultHTML += `<p><strong>Fecha de inicio:</strong> ${formatDate(startDate)}</p>`;
   resultHTML += `<p><strong>Plazo inicial:</strong> ${initialDays} días</p>`;
 
@@ -226,7 +227,7 @@ function calculate() {
   }
 
   const fojasIniciales = countFojas(startDate, currentDate, pauses);
-  resultHTML += `<p><strong>Fojas totales:</strong> ${fojasIniciales}</p>`;
+  resultHTML += `<p><strong>Foja Nº Final:</strong> ${fojasIniciales} FINAL</p>`;
   if (showWarning) {
     resultHTML += `<p class="warning">Si paralizás la obra con fecha posterior al inicio, debés generar una foja un día antes de la paralización.</p>`;
   }
@@ -276,21 +277,31 @@ function openPdfReport() {
     },
     callback: function (doc) {
       const pageH = doc.internal.pageSize.getHeight();
+      const pageW = doc.internal.pageSize.getWidth();
       doc.setFontSize(10);
       doc.setTextColor(0, 0, 0); // Black text
-      doc.text('Gracias por usar la app de Certy!', 40, pageH - 20);
 
-      // Restore original styles
-      for (let el in originalStyles) {
-        if (el.style) {
-          el.style.color = originalStyles[el].color;
-          el.style.backgroundColor = originalStyles[el].backgroundColor;
+      const finalize = () => {
+        for (let el in originalStyles) {
+          if (el.style) {
+            el.style.color = originalStyles[el].color;
+            el.style.backgroundColor = originalStyles[el].backgroundColor;
+          }
         }
-      }
+        doc.save('ReporteCertyApp.pdf');
+      };
 
-      const pdfBlob = doc.output('blob');
-      const url = URL.createObjectURL(pdfBlob);
-      window.open(url, '_blank');
+      const img = new Image();
+      img.src = 'logo.png';
+      img.onload = function() {
+        const imgSize = 24;
+        const xImg = pageW - 40 - imgSize;
+        const yImg = pageH - imgSize - 20;
+        doc.addImage(img, 'PNG', xImg, yImg, imgSize, imgSize);
+        doc.text('Gracias por usar la app de Certy!', xImg - 10, pageH - 20, { align: 'right' });
+        finalize();
+      };
+      img.onerror = finalize;
     }
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,14 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
 
 body {
   font-family: 'Inter', sans-serif;
-  background: linear-gradient(to right, #2b2d42, #8d99ae);
-  color: #edf2f4;
+  background: radial-gradient(circle at center, #0a0a0f 0%, #000000 100%);
+  color: #00e0e0;
   margin: 0;
   padding: 140px 0 120px 0; /* espacio para el banner fijo */
+  animation: pulseBG 10s ease-in-out infinite alternate;
 }
 
 body.big-text {
@@ -49,12 +51,13 @@ body.light-mode .logo {
 .container {
   max-width: 600px;
   margin: 2rem auto;
-  background: rgba(26, 28, 44, 0.85); /* glass effect */
+  background: rgba(0, 0, 0, 0.6);
   padding: 2rem;
-  border-radius: 15px;
-  box-shadow: 0 0 15px rgba(0,0,0,0.4);
+  border-radius: 12px;
+  border: 1px solid #00f0ff;
+  box-shadow: 0 0 20px #00f0ff;
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  animation: fadeIn 1s ease forwards, borderGlow 5s linear infinite;
 }
 
 body.light-mode .container {
@@ -66,6 +69,9 @@ h1 {
   text-align: center;
   font-size: 2rem;
   margin-bottom: 0.5rem;
+  font-family: 'Orbitron', sans-serif;
+  color: #00f0ff;
+  text-shadow: 0 0 10px #00f0ff, 0 0 20px #00f0ff;
 }
 
 .pixel {
@@ -77,6 +83,21 @@ h1 {
   line-height: 1.4; /* Improved line height for better readability */
   margin: 0 auto; /* Center the text block */
   max-width: 100%; /* Ensure it doesn't overflow container */
+}
+
+@keyframes pulseBG {
+  0% { background: radial-gradient(circle at center, #0a0a0f 0%, #000000 100%); }
+  100% { background: radial-gradient(circle at center, #0d0d14 0%, #000000 100%); }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes borderGlow {
+  0%, 100% { box-shadow: 0 0 10px #00f0ff, 0 0 20px #00e0e0; }
+  50% { box-shadow: 0 0 20px #00f0ff, 0 0 30px #00e0e0; }
 }
 
 body.light-mode .pixel {
@@ -109,8 +130,10 @@ body.light-mode .pixel {
   text-align: center;
   font-size: 1rem;
   font-style: italic;
-  color: #d3d3d3;
+  color: #00e0e0;
   margin-bottom: 2rem;
+  font-family: 'Orbitron', sans-serif;
+  text-shadow: 0 0 10px #00f0ff, 0 0 20px #00f0ff;
 }
 
 body.light-mode .subtitle {
@@ -126,11 +149,21 @@ input,
 select {
   width: 100%;
   padding: 0.7rem;
-  border: none;
+  background: rgba(0,0,0,0.6);
+  border: 1px solid #00f0ff;
   border-radius: 8px;
   margin-bottom: 1.2rem;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
   font-size: 1rem;
+  color: #00e0e0;
+  transition: box-shadow 0.3s ease;
+}
+
+input:hover,
+input:focus,
+select:hover,
+select:focus {
+  box-shadow: 0 0 10px #00f0ff, 0 0 20px #00f0ff inset;
+  outline: none;
 }
 
 .pauseRange,
@@ -144,14 +177,14 @@ button {
   margin: 2rem auto 0 auto;
   font-size: 1.1rem;
   padding: 1rem 2rem;
-  background-color: #ef233c;
-  color: white;
-  border: none;
+  background: transparent;
+  color: #00f0ff;
+  border: 2px solid #00f0ff;
   border-radius: 10px;
   font-weight: bold;
   cursor: pointer;
-  transition: all 0.3s ease;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  transition: 0.3s;
+  box-shadow: 0 0 15px #00f0ff;
 }
 
 body.light-mode button {
@@ -159,8 +192,9 @@ body.light-mode button {
 }
 
 button:hover {
-  background-color: #d90429;
-  transform: scale(1.05);
+  background: #00f0ff;
+  color: #000;
+  box-shadow: 0 0 25px #00f0ff;
 }
 
 .button-row {
@@ -176,24 +210,28 @@ button:hover {
 
 .backBtn {
   background: transparent;
-  color: #fff;
-  border: 1px solid #fff;
+  border: 2px solid #00f0ff;
+  color: #00f0ff;
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
   font-size: 0.9rem;
+  box-shadow: 0 0 15px #00f0ff;
+  transition: 0.3s;
 }
 
 body.light-mode .backBtn {
   color: #000;
   border-color: #000;
+  box-shadow: none;
 }
 
 .backBtn:hover {
-  background: rgba(255,255,255,0.1);
+  background: #00f0ff;
+  color: #000;
+  box-shadow: 0 0 25px #00f0ff;
 }
 
 #printBtn {
-  background-color: #25D366;
   margin-top: 2rem;
   margin-bottom: 4rem;
 }
@@ -234,26 +272,26 @@ body.light-mode .backBtn {
 
 .menu {
   text-align: center;
-  background: #001b33;
+  background: rgba(0,0,0,0.6);
   padding: 2rem;
-  border-radius: 15px;
-  box-shadow: 0 0 15px rgba(0,255,255,0.4);
+  border-radius: 12px;
+  border: 1px solid #00f0ff;
+  box-shadow: 0 0 20px #00f0ff;
 }
 
 body.light-mode .menu {
   background: #e0e0e0;
+  border: 1px solid #000;
   box-shadow: 0 0 15px rgba(0,0,0,0.2);
 }
 
 .menu button {
   width: 100%;
-  background-color: #1b9aaa;
-  box-shadow: 0 0 10px rgba(0,255,255,0.7);
 }
 
 body.light-mode .menu button {
-  background-color: #1976d2;
-  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+  background-color: transparent;
+  box-shadow: none;
 }
 
 #downloadAppBtn {


### PR DESCRIPTION
## Summary
- switch to a dark neon theme with glowing inputs and buttons
- show foja number with FINAL and rename PDF to ReporteCertyApp
- update PDF header and footer with centered title and logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e229aa12c832eb74a5348084f46a0