### PR TITLE
Default to light theme and refine UI

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
 <body>
-  <button id="themeToggle">🌙</button>
+  <button id="themeToggle">🌞</button>
   <div class="logo-container">
     <img src="logo.png" alt="Logo Neuquén Capital" class="logo" />
   </div>

--- a/common.js
+++ b/common.js
@@ -7,12 +7,11 @@ document.addEventListener('DOMContentLoaded', () => {
       document.body.classList.toggle('dark-mode', theme === 'dark');
       toggle.textContent = theme === 'light' ? '🌞' : '🌙';
     };
-    const saved = localStorage.getItem('theme') || 'light';
-    applyTheme(saved);
+    let currentTheme = 'light';
+    applyTheme(currentTheme);
     toggle.addEventListener('click', () => {
-      const newTheme = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
-      localStorage.setItem('theme', newTheme);
-      applyTheme(newTheme);
+      currentTheme = currentTheme === 'light' ? 'dark' : 'light';
+      applyTheme(currentTheme);
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
-  <button id="themeToggle">🌙</button>
+    <button id="themeToggle">🌞</button>
   <div class="logo-container">
     <img src="logo.png" alt="Logo Neuquén Capital" class="logo">
   </div>
@@ -16,8 +16,8 @@
       <img src="Robot.png" alt="Certy Robot" class="robot">
       <h1>¡Hola! Soy Certy, ¿Qué vamos a hacer hoy?<span class="cursor">_</span></h1>
       <p class="subtitle">Seleccioná una opción para continuar</p>
-      <button onclick="window.location.href='calculator.html'">Calculadora de Días y Fojas para obras</button>
-      <button onclick="window.location.href='project.html'">Calculadora de Días y Fojas para PROYECTOS</button>
+        <button onclick="window.location.href='calculator.html'">Calculadora de Días y Fojas para <strong>OBRAS</strong></button>
+        <button onclick="window.location.href='project.html'">Calculadora de Días y Fojas para <strong>PROYECTO</strong></button>
       <button disabled>Próximamente más funciones</button>
   </div>
 <button id="downloadAppBtn" onclick="installApp()">

--- a/project.html
+++ b/project.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
 <body>
-  <button id="themeToggle">🌙</button>
+  <button id="themeToggle">🌞</button>
   <div class="logo-container">
     <img src="logo.png" alt="Logo Neuquén Capital" class="logo" />
   </div>

--- a/project.js
+++ b/project.js
@@ -199,6 +199,17 @@ function openPdfReport() {
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
   const resultEl = document.getElementById('result');
+  const originalWordSpacing = resultEl.style.wordSpacing;
+  const textNodes = [];
+  const walker = document.createTreeWalker(resultEl, NodeFilter.SHOW_TEXT, null, false);
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    if (node.nodeValue.includes(':')) {
+      textNodes.push({ node, text: node.nodeValue });
+      node.nodeValue = node.nodeValue.replace(/:/g, ' :');
+    }
+  }
+  resultEl.style.wordSpacing = '4px';
 
   const originalStyles = {};
   const elements = resultEl.getElementsByTagName('*');
@@ -234,6 +245,8 @@ function openPdfReport() {
             el.style.backgroundColor = originalStyles[el].backgroundColor;
           }
         }
+        textNodes.forEach(({ node, text }) => (node.nodeValue = text));
+        resultEl.style.wordSpacing = originalWordSpacing;
         const blobUrl = doc.output('bloburl');
         window.open(blobUrl, '_blank');
       };
@@ -241,7 +254,7 @@ function openPdfReport() {
       const img = new Image();
       img.src = 'Robot.png';
       img.onload = function() {
-        const imgSize = 32;
+        const imgSize = 16;
         const xImg = pageW - 40 - imgSize;
         const yImg = pageH - imgSize - 20;
         doc.addImage(img, 'PNG', xImg, yImg, imgSize, imgSize);

--- a/script.js
+++ b/script.js
@@ -236,7 +236,7 @@ function calculate() {
   const fojasIniciales = countFojas(startDate, currentDate, pauses);
   resultHTML += `<p><strong>Foja Nº Final:</strong> ${fojasIniciales} FINAL</p>`;
   if (showWarning) {
-    resultHTML += `<p class="warning">Si paralizás la obra con fecha posterior al inicio, debés generar una foja un día antes de la paralización.</p>`;
+    resultHTML += `<p class="warning">OJO! ten en cuenta que si paralizás la obra con fecha posterior al inicio, debés generar una foja un día antes de la paralización.</p>`;
   }
   resultHTML += generarTablaFojas(startDate, currentDate, pauses);
 
@@ -259,6 +259,17 @@ function openPdfReport() {
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
   const resultEl = document.getElementById('result');
+  const originalWordSpacing = resultEl.style.wordSpacing;
+  const textNodes = [];
+  const walker = document.createTreeWalker(resultEl, NodeFilter.SHOW_TEXT, null, false);
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    if (node.nodeValue.includes(':')) {
+      textNodes.push({ node, text: node.nodeValue });
+      node.nodeValue = node.nodeValue.replace(/:/g, ' :');
+    }
+  }
+  resultEl.style.wordSpacing = '4px';
 
   // Save original styles
   const originalStyles = {};
@@ -269,7 +280,6 @@ function openPdfReport() {
         color: el.style.color,
         backgroundColor: el.style.backgroundColor
       };
-      // Force black text and white background for PDF
       el.style.color = '#000000';
       el.style.backgroundColor = '#FFFFFF';
     }
@@ -296,6 +306,8 @@ function openPdfReport() {
             el.style.backgroundColor = originalStyles[el].backgroundColor;
           }
         }
+        textNodes.forEach(({ node, text }) => (node.nodeValue = text));
+        resultEl.style.wordSpacing = originalWordSpacing;
         const blobUrl = doc.output('bloburl');
         window.open(blobUrl, '_blank');
       };
@@ -303,7 +315,7 @@ function openPdfReport() {
       const img = new Image();
       img.src = 'Robot.png';
       img.onload = function() {
-        const imgSize = 32;
+        const imgSize = 16;
         const xImg = pageW - 40 - imgSize;
         const yImg = pageH - imgSize - 20;
         doc.addImage(img, 'PNG', xImg, yImg, imgSize, imgSize);

--- a/styles.css
+++ b/styles.css
@@ -52,7 +52,7 @@ h1 {
 .menu .robot {
   display: block;
   margin: 0 auto 1rem;
-  max-width: 120px;
+  max-width: 60px;
 }
 
 .menu button {
@@ -108,6 +108,8 @@ button {
   color: #fff;
   cursor: pointer;
   transition: background 0.3s, box-shadow 0.3s;
+  font-size: 1.1rem;
+  text-transform: uppercase;
 }
 
 button:hover {
@@ -191,4 +193,12 @@ body.dark-mode #themeToggle {
 .suggestion {
   font-size: 0.9rem;
   color: #666;
+}
+
+.warning {
+  background-color: #ffd8a8;
+  border: 1px solid #ffa94d;
+  padding: 0.5rem;
+  border-radius: 4px;
+  font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- Default UI to light mode with sun icon toggle and no theme persistence.
- Enlarge buttons, uppercase labels, highlight OBRAS/PROYECTO options, and shrink robot graphic.
- Emphasize warning about late suspensions and improve PDF formatting with extra word spacing and colon spacing.

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688e3ddcbb8c832ea07b3a65e7dd5a0f