### PR TITLE
Improve menu button casing and sticky headers

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -16,13 +16,13 @@
 <body>
   <button id="themeToggle">🌞</button>
   <div class="logo-container">
-    <img src="logo.png" alt="Logo Neuquén Capital" class="logo" />
+    <img src="logo_obra.png" alt="Logo Neuquén Capital Obras" class="logo" />
   </div>
 
     <div class="container form-container">
       <button class="backBtn" onclick="window.location.href='index.html'">Volver al menú</button>
       <h1>Calculadora de Días y Fojas</h1>
-      <p class="subtitle">Hola! con la siguiente calculadora vamos a calcular la fecha de finalización de la obra y fojas a realizar.</p>
+      <p class="subtitle">Con la siguiente calculadora vamos a calcular la fecha de finalización de la obra y fojas a realizar.</p>
 
     
     <label>Fecha de inicio de obra:

--- a/index.html
+++ b/index.html
@@ -15,10 +15,10 @@
   <div class="container menu">
       <img src="Robot.png" alt="Certy Robot" class="robot">
       <h1>¡Hola! Soy Certy, ¿Qué vamos a hacer hoy?<span class="cursor">_</span></h1>
-      <p class="subtitle">Seleccioná una opción para continuar</p>
-        <button onclick="window.location.href='calculator.html'">Calculadora de Días y Fojas para <strong>OBRAS</strong></button>
-        <button onclick="window.location.href='project.html'">Calculadora de Días y Fojas para <strong>PROYECTO</strong></button>
-      <button disabled>Próximamente más funciones</button>
+        <p class="subtitle">Seleccioná una opción para continuar</p>
+          <button onclick="window.location.href='calculator.html'">Calculadora de Días y Fojas para <strong>OBRAS</strong></button>
+          <button onclick="window.location.href='project.html'">Calculadora de Días y Fojas para <strong>PROYECTOS</strong></button>
+        <button class="coming-soon" disabled>PRÓXIMAMENTE MÁS FUNCIONES</button>
   </div>
 <button id="downloadAppBtn" onclick="installApp()">
   DESCARGAR CERTY EN TU CELULAR!<br><em>Sólo válido para Android</em>

--- a/project.html
+++ b/project.html
@@ -16,13 +16,13 @@
 <body>
   <button id="themeToggle">🌞</button>
   <div class="logo-container">
-    <img src="logo.png" alt="Logo Neuquén Capital" class="logo" />
+    <img src="logo_proyecto.png" alt="Logo Neuquén Capital Proyectos" class="logo" />
   </div>
 
   <div class="container form-container">
     <button class="backBtn" onclick="window.location.href='index.html'">Volver al menú</button>
     <h1>Calculadora de Días y Fojas para PROYECTOS</h1>
-    <p class="subtitle">Hola! con la siguiente calculadora vamos a calcular la fecha de finalización del proyecto y fojas a realizar.</p>
+    <p class="subtitle">Con la siguiente calculadora vamos a calcular la fecha de finalización del proyecto y fojas a realizar.</p>
 
     <label>Fecha de inicio de obra:
       <input type="date" id="startDate" placeholder="Ingrese fecha" />

--- a/styles.css
+++ b/styles.css
@@ -5,12 +5,18 @@ body {
   background-color: #f8f9fa;
   color: #333;
   margin: 0;
+  padding-top: 120px;
 }
 
 .logo-container {
   background: rgb(1, 5, 10);
   text-align: center;
   padding: 10px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1000;
 }
 
 .logo {
@@ -59,6 +65,12 @@ h1 {
   display: block;
   width: 100%;
   margin: 0.5rem 0;
+  text-transform: none;
+}
+
+.menu button.coming-soon {
+  margin-top: 1.5rem;
+  text-transform: uppercase;
 }
 
 .subtitle {
@@ -138,6 +150,7 @@ button:hover {
   border: none;
   font-size: 1.5rem;
   cursor: pointer;
+  z-index: 1100;
 }
 
 #downloadAppBtn {


### PR DESCRIPTION
## Summary
- Keep main menu buttons mixed case with bold all-caps OBRAS/PROYECTOS
- Swap calculator headers to specific logos and drop the greeting line
- Fix header bar at top of page and space out the 'PRÓXIMAMENTE MÁS FUNCIONES' button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e46fc41f4832ea5433aabb49763aa