### PR TITLE
Ajustes calculadora de proyectos y botón de tema

### DIFF
--- a/project.js
+++ b/project.js
@@ -17,15 +17,27 @@ function formatDate(date) {
 
 function buildFojas(startDate, finalDate, suspensions = []) {
   const fojas = [];
-  let inicio = startDate;
-  suspensions.forEach(([, sEnd]) => {
-    const fojaFin = addDays(sEnd, 1);
-    fojas.push({ desde: formatDate(inicio), hasta: formatDate(fojaFin) });
-    inicio = addDays(fojaFin, 1);
-  });
-  if (inicio <= finalDate) {
-    fojas.push({ desde: formatDate(inicio), hasta: formatDate(finalDate) });
+  const sorted = suspensions.sort((a, b) => a[0] - b[0]);
+  let currentStart = new Date(startDate);
+
+  while (currentStart <= finalDate) {
+    const nextBreak = addDays(currentStart, 29);
+    const nextSusp = sorted.length ? sorted[0] : null;
+
+    if (nextSusp && nextSusp[0] <= nextBreak) {
+      const measurement = addDays(nextSusp[1], 1);
+      fojas.push({ desde: formatDate(currentStart), hasta: formatDate(measurement) });
+      currentStart = addDays(measurement, 1);
+      sorted.shift();
+    } else if (nextBreak <= finalDate) {
+      fojas.push({ desde: formatDate(currentStart), hasta: formatDate(nextBreak) });
+      currentStart = addDays(nextBreak, 1);
+    } else {
+      fojas.push({ desde: formatDate(currentStart), hasta: formatDate(finalDate) });
+      break;
+    }
   }
+
   return fojas;
 }
 
@@ -312,7 +324,7 @@ document.getElementById("hasSuspensions").addEventListener("change", function ()
       for (let i = 1; i <= count; i++) {
         container.innerHTML += `
           <div class="suspensionGroup">
-            <p class="suspensionSuggestion warning"></p>
+            <p class="suspensionSuggestion suggestion-box suggestion"></p>
             <label>Suspensión ${i}:
               <input type="text" class="suspensionRange" placeholder="Seleccionar rango"/>
             </label>

--- a/styles.css
+++ b/styles.css
@@ -159,12 +159,13 @@ button:hover {
 .suggestion-date {
   font-weight: bold;
   font-size: 1.1rem;
+  text-decoration: underline;
 }
 
 #themeToggle {
   position: fixed;
   top: 10px;
-  left: 10px;
+  right: 10px;
   background: transparent;
   border: none;
   font-size: 1.5rem;
@@ -225,6 +226,13 @@ body.dark-mode #themeToggle {
 .suggestion {
   font-size: 0.9rem;
   color: #666;
+}
+
+.suggestion-box {
+  background-color: #ffd8a8;
+  border: 1px solid #ffa94d;
+  padding: 0.5rem;
+  border-radius: 4px;
 }
 
 .warning {


### PR DESCRIPTION
## Summary
- Mover botón de cambio de tema a la derecha para no superponerlo con la navegación.
- Ajustar estilo de sugerencias en calculadora de proyectos dejando sólo la fecha en negrita y subrayado.
- Corregir cálculo y detalle de fojas en proyectos contemplando periodos mayores a 30 días y suspensiones.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e5f4fa4c0832e896db524953027c1