### PR TITLE
Improve mobile menu and PDF report

### DIFF
--- a/common.js
+++ b/common.js
@@ -15,6 +15,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const ua = navigator.userAgent || '';
+  const isIpad2 = /iPad/.test(ua) && window.devicePixelRatio === 1;
+  if (isIpad2) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'ipad2.css';
+    document.head.appendChild(link);
+  }
 });
 
 function installApp() {

--- a/ipad2.css
+++ b/ipad2.css
@@ -1,0 +1,26 @@
+/* Simplified design for iPad 2 devices */
+body {
+  font-family: Arial, sans-serif;
+  background: #ffffff;
+  color: #000000;
+  padding-top: 80px;
+}
+
+.logo-container {
+  position: static;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.container {
+  box-shadow: none;
+  border: 1px solid #ddd;
+  margin: 0.5rem;
+  padding: 1rem;
+  max-width: 100%;
+}
+
+button {
+  box-shadow: none;
+}
+

--- a/project.js
+++ b/project.js
@@ -234,8 +234,14 @@ function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
-        const blobUrl = doc.output('bloburl');
-        window.open(blobUrl, '_blank');
+        const blob = doc.output('blob');
+        const url = URL.createObjectURL(blob);
+        const pdfWindow = window.open('', '_blank');
+        if (pdfWindow) {
+          pdfWindow.document.write(`<iframe width='100%' height='100%' src='${url}'></iframe>`);
+        } else {
+          window.location.href = url;
+        }
       };
 
       const img = new Image();

--- a/script.js
+++ b/script.js
@@ -308,8 +308,14 @@ function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
-        const blobUrl = doc.output('bloburl');
-        window.open(blobUrl, '_blank');
+        const blob = doc.output('blob');
+        const url = URL.createObjectURL(blob);
+        const pdfWindow = window.open('', '_blank');
+        if (pdfWindow) {
+          pdfWindow.document.write(`<iframe width='100%' height='100%' src='${url}'></iframe>`);
+        } else {
+          window.location.href = url;
+        }
       };
 
       const img = new Image();

--- a/styles.css
+++ b/styles.css
@@ -52,7 +52,7 @@ h1 {
 }
 
 .menu h1 {
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .menu .robot {
@@ -241,4 +241,21 @@ body.dark-mode #themeToggle {
   padding: 0.5rem;
   border-radius: 4px;
   font-weight: bold;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding-top: 90px;
+  }
+  .container.menu {
+    margin: 1rem;
+    padding: 1rem;
+    max-width: 100%;
+  }
+  .menu .robot {
+    max-width: 50px;
+  }
+  .menu h1 {
+    font-size: 1.2rem;
+  }
 }


### PR DESCRIPTION
## Summary
- Adjust menu styles to better fit mobile screens
- Render generated PDF in a new window
- Apply lightweight styles when running on iPad 2

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Certy_app/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688e666223f8832e9c4aedcd65169d48