### PR TITLE
Fix PDF report and add legacy Safari support

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -12,6 +12,7 @@
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.min.js"></script>
 </head>
 <body>
   <button id="themeToggle">🌞</button>
@@ -60,7 +61,7 @@
     <button id="printBtn" onclick="openPdfReport()" style="display:none;">Imprimir informe en PDF</button>
   </div>
 
-  <script src="common.js"></script>
-  <script src="script.js"></script>
+  <script type="text/babel" src="common.js"></script>
+  <script type="text/babel" src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -25,14 +25,15 @@
 </button>
 <script>
   window.addEventListener('load', function() {
-    const btn = document.getElementById('downloadAppBtn');
-    setTimeout(() => {
+    var btn = document.getElementById('downloadAppBtn');
+    setTimeout(function() {
       btn.classList.add('hide');
-      setTimeout(() => btn.style.display = 'none', 500);
+      setTimeout(function() { btn.style.display = 'none'; }, 500);
     }, 3000);
   });
 </script>
-<script src="common.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.min.js"></script>
+<script type="text/babel" src="common.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.4.9/mammoth.browser.min.js"></script>
 </body>

--- a/project.html
+++ b/project.html
@@ -12,6 +12,7 @@
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.min.js"></script>
 </head>
 <body>
   <button id="themeToggle">🌞</button>
@@ -59,7 +60,7 @@
     <button id="printBtn" onclick="openPdfReport()" style="display:none;">Imprimir informe en PDF</button>
   </div>
 
-  <script src="common.js"></script>
-  <script src="project.js"></script>
+  <script type="text/babel" src="common.js"></script>
+  <script type="text/babel" src="project.js"></script>
 </body>
 </html>

--- a/project.js
+++ b/project.js
@@ -183,6 +183,7 @@ function clearAll() {
 }
 
 function openPdfReport() {
+  const pdfWindow = window.open('', '_blank');
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
   const resultEl = document.getElementById('result');
@@ -236,9 +237,8 @@ function openPdfReport() {
         resultEl.style.wordSpacing = originalWordSpacing;
         const blob = doc.output('blob');
         const url = URL.createObjectURL(blob);
-        const pdfWindow = window.open('', '_blank');
         if (pdfWindow) {
-          pdfWindow.document.write(`<iframe width='100%' height='100%' src='${url}'></iframe>`);
+          pdfWindow.location.href = url;
         } else {
           window.location.href = url;
         }

--- a/script.js
+++ b/script.js
@@ -256,6 +256,7 @@ function clearAll() {
 }
 
 function openPdfReport() {
+  const pdfWindow = window.open('', '_blank');
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
   const resultEl = document.getElementById('result');
@@ -310,9 +311,8 @@ function openPdfReport() {
         resultEl.style.wordSpacing = originalWordSpacing;
         const blob = doc.output('blob');
         const url = URL.createObjectURL(blob);
-        const pdfWindow = window.open('', '_blank');
         if (pdfWindow) {
-          pdfWindow.document.write(`<iframe width='100%' height='100%' src='${url}'></iframe>`);
+          pdfWindow.location.href = url;
         } else {
           window.location.href = url;
         }


### PR DESCRIPTION
## Summary
- ensure PDF reports open correctly by preparing window before rendering
- add Babel transpilation and legacy-safe inline scripts for iPad2 Safari

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e693d5044832e9c10213ed40b2274