### PR TITLE
fix: show calculators without blank screen

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -11,8 +11,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
 <body>
   <button id="themeToggle">🌞</button>
@@ -61,7 +60,7 @@
     <button id="printBtn" onclick="openPdfReport()" style="display:none;">Imprimir informe en PDF</button>
   </div>
 
-  <script type="text/babel" src="common.js"></script>
-  <script type="text/babel" src="script.js"></script>
+    <script src="common.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -32,8 +32,7 @@
     }, 3000);
   });
 </script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.min.js"></script>
-<script type="text/babel" src="common.js"></script>
+<script src="common.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.4.9/mammoth.browser.min.js"></script>
 </body>

--- a/project.html
+++ b/project.html
@@ -11,8 +11,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/es.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
 <body>
   <button id="themeToggle">🌞</button>
@@ -60,7 +59,7 @@
     <button id="printBtn" onclick="openPdfReport()" style="display:none;">Imprimir informe en PDF</button>
   </div>
 
-  <script type="text/babel" src="common.js"></script>
-  <script type="text/babel" src="project.js"></script>
+    <script src="common.js"></script>
+    <script src="project.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load common.js directly in index
- drop babel-standalone and use plain scripts for calculators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e6febe1bc832e8497994e1bbf6473