### PR TITLE
Fix PDF report button

### DIFF
--- a/project.js
+++ b/project.js
@@ -183,7 +183,6 @@ function clearAll() {
 }
 
 function openPdfReport() {
-  const pdfWindow = window.open('', '_blank');
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
   const resultEl = document.getElementById('result');
@@ -237,11 +236,11 @@ function openPdfReport() {
         resultEl.style.wordSpacing = originalWordSpacing;
         const blob = doc.output('blob');
         const url = URL.createObjectURL(blob);
-        if (pdfWindow) {
-          pdfWindow.location.href = url;
-        } else {
-          window.location.href = url;
-        }
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'informe.pdf';
+        link.click();
+        URL.revokeObjectURL(url);
       };
 
       const img = new Image();

--- a/script.js
+++ b/script.js
@@ -256,7 +256,6 @@ function clearAll() {
 }
 
 function openPdfReport() {
-  const pdfWindow = window.open('', '_blank');
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
   const resultEl = document.getElementById('result');
@@ -311,11 +310,11 @@ function openPdfReport() {
         resultEl.style.wordSpacing = originalWordSpacing;
         const blob = doc.output('blob');
         const url = URL.createObjectURL(blob);
-        if (pdfWindow) {
-          pdfWindow.location.href = url;
-        } else {
-          window.location.href = url;
-        }
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'informe.pdf';
+        link.click();
+        URL.revokeObjectURL(url);
       };
 
       const img = new Image();


### PR DESCRIPTION
## Summary
- ensure PDF report generation triggers a download instead of opening a blank window

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e77cff6d8832eb7ab061796824902