### PR TITLE
Move header buttons and fix PDF download

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -14,10 +14,10 @@
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
 <body>
-  <button id="themeToggle">🌞</button>
   <div class="logo-container">
-    <button class="backBtn" onclick="window.location.href='index.html'">Volver al menú</button>
     <img src="logo_obra.png" alt="Logo Neuquén Capital Obras" class="logo" />
+    <button class="backBtn" onclick="window.location.href='index.html'">Volver al menú</button>
+    <button id="themeToggle">🌞</button>
   </div>
 
     <div class="container form-container">

--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
-    <button id="themeToggle">🌞</button>
   <div class="logo-container">
     <img src="logo.png" alt="Logo Neuquén Capital" class="logo">
+    <button id="themeToggle">🌞</button>
   </div>
   <div class="container menu">
       <img src="Robot.png" alt="Certy Robot" class="robot">

--- a/project.html
+++ b/project.html
@@ -14,10 +14,10 @@
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
 <body>
-  <button id="themeToggle">🌞</button>
   <div class="logo-container">
-    <button class="backBtn" onclick="window.location.href='index.html'">Volver al menú</button>
     <img src="logo_proyecto.png" alt="Logo Neuquén Capital Proyectos" class="logo" />
+    <button class="backBtn" onclick="window.location.href='index.html'">Volver al menú</button>
+    <button id="themeToggle">🌞</button>
   </div>
 
   <div class="container form-container">

--- a/project.js
+++ b/project.js
@@ -234,13 +234,7 @@ function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
-        const blob = doc.output('blob');
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = 'informe.pdf';
-        link.click();
-        URL.revokeObjectURL(url);
+        doc.save('informe.pdf');
       };
 
       const img = new Image();

--- a/script.js
+++ b/script.js
@@ -308,13 +308,7 @@ function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
-        const blob = doc.output('blob');
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = 'informe.pdf';
-        link.click();
-        URL.revokeObjectURL(url);
+        doc.save('informe.pdf');
       };
 
       const img = new Image();

--- a/styles.css
+++ b/styles.css
@@ -11,7 +11,7 @@ body {
 .logo-container {
   background: rgb(1, 5, 10);
   text-align: center;
-  padding: 10px;
+  padding: 10px 10px 50px;
   position: fixed;
   top: 0;
   left: 0;
@@ -152,8 +152,7 @@ button:hover {
 .logo-container .backBtn {
   position: absolute;
   left: 10px;
-  top: 50%;
-  transform: translateY(-50%);
+  bottom: 10px;
 }
 
 .suggestion-date {
@@ -162,10 +161,10 @@ button:hover {
   text-decoration: underline;
 }
 
-#themeToggle {
-  position: fixed;
-  top: 10px;
+.logo-container #themeToggle {
+  position: absolute;
   right: 10px;
+  bottom: 10px;
   background: transparent;
   border: none;
   font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- reposition back-to-menu and theme toggle to bottom of header
- use jsPDF's save method so PDF download works on APK

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f9380fdbc832ebdc4aa2b4b1fe251