### PR TITLE
Open PDF in new tab and resize header

### DIFF
--- a/project.js
+++ b/project.js
@@ -234,7 +234,10 @@ function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
-        doc.save('informe.pdf');
+        const pdfBlob = doc.output('blob');
+        const pdfUrl = URL.createObjectURL(pdfBlob);
+        window.open(pdfUrl, '_blank');
+        setTimeout(() => URL.revokeObjectURL(pdfUrl), 1000);
       };
 
       const img = new Image();

--- a/script.js
+++ b/script.js
@@ -308,7 +308,10 @@ function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
-        doc.save('informe.pdf');
+        const pdfBlob = doc.output('blob');
+        const pdfUrl = URL.createObjectURL(pdfBlob);
+        window.open(pdfUrl, '_blank');
+        setTimeout(() => URL.revokeObjectURL(pdfUrl), 1000);
       };
 
       const img = new Image();

--- a/styles.css
+++ b/styles.css
@@ -11,16 +11,17 @@ body {
 .logo-container {
   background: rgb(1, 5, 10);
   text-align: center;
-  padding: 10px 10px 50px;
+  padding: 10px;
   position: fixed;
   top: 0;
-  left: 0;
-  width: 100%;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 1000;
+  display: inline-block;
 }
 
 .logo {
-  width: 80%;
+  width: 100%;
   max-width: 300px;
   height: auto;
 }


### PR DESCRIPTION
## Summary
- Generate PDF reports in memory and open in a new browser tab without triggering download dialogs
- Restore logo header to its original width while keeping corner buttons anchored at the bottom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f965bdcd4832eb8cb8ebafc0667fb