### PR TITLE
Add paralización request and improve header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <p class="subtitle">Seleccioná una opción para continuar</p>
           <button onclick="window.location.href='calculator.html'">Calculadora de Días y Fojas para <strong>OBRAS</strong></button>
           <button onclick="window.location.href='project.html'">Calculadora de Días y Fojas para <strong>PROYECTOS</strong></button>
+          <button class="btn-paralizacion" onclick="window.location.href='paralizacion.html'">Solicitar Paralización (Próximamente)</button>
         <button class="coming-soon" disabled>PRÓXIMAMENTE MÁS FUNCIONES</button>
   </div>
 <button id="downloadAppBtn" onclick="installApp()">

--- a/paralizacion.html
+++ b/paralizacion.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Solicitar Paralización</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="logo-container">
+    <img src="logo_obra.png" alt="Logo Neuquén Capital Obras" class="logo" />
+    <button class="backBtn" onclick="window.location.href='index.html'">Volver al menú</button>
+    <button id="themeToggle">🌞</button>
+  </div>
+
+  <div class="container form-container">
+    <h1>Solicitar Paralización</h1>
+    <label>N° de expediente:
+      <input type="text" id="expedienteInput" />
+      <small class="suggestion"><em>Ej: 00125-M-2025</em></small>
+    </label>
+    <div class="button-row">
+      <button onclick="buscarExpediente()">BUSCAR</button>
+    </div>
+    <div id="alert" class="alert-error" style="display:none;"></div>
+    <div id="datosObra" style="display:none;">
+      <p><strong>Obra:</strong> <span id="obraNombre"></span></p>
+      <p><strong>Fecha de Inicio:</strong> <span id="fechaInicio"></span></p>
+      <p><strong>Contratista:</strong> <span id="contratista"></span></p>
+      <label>Fecha de solicitud de paralización:
+        <input type="date" id="fechaSolicitud" />
+      </label>
+      <label>Motivo de la paralización:
+        <textarea id="motivo" rows="4"></textarea>
+        <small class="suggestion"><em>En esta instancia no es necesario explayarse en el motivo, ya que es solo para la apertura del expediente.
+Ejemplo: El motivo que justifica dicha paralización radica en los plazos pendientes de aprobación del proyecto ejecutivo presentado en CALF por parte de la empresa contratista, así como en dificultades vinculadas a la adquisición de materiales.</em></small>
+      </label>
+    </div>
+  </div>
+
+  <script src="common.js"></script>
+  <script src="paralizacion.js"></script>
+</body>
+</html>

--- a/paralizacion.js
+++ b/paralizacion.js
@@ -1,0 +1,38 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const container = document.querySelector('.form-container');
+  if (container) {
+    container.classList.add('loaded');
+  }
+});
+
+async function buscarExpediente() {
+  const exp = document.getElementById('expedienteInput').value.trim();
+  const alertEl = document.getElementById('alert');
+  const datosDiv = document.getElementById('datosObra');
+  alertEl.style.display = 'none';
+  datosDiv.style.display = 'none';
+  if (!exp) return;
+
+  const sheetId = '1ZSAeRUOVsRJl5SXCV08QEQ4taLpQX686C9GcmMWpG1Q';
+  const query = `select A,B,C,D where A='${exp}'`;
+  const url = `https://docs.google.com/spreadsheets/d/${sheetId}/gviz/tq?tqx=out:json&sheet=Hoja1&tq=${encodeURIComponent(query)}`;
+
+  try {
+    const res = await fetch(url);
+    const text = await res.text();
+    const json = JSON.parse(text.substring(text.indexOf('{'), text.lastIndexOf('}') + 1));
+    if (json.table.rows.length > 0) {
+      const row = json.table.rows[0].c;
+      document.getElementById('obraNombre').textContent = row[1] ? row[1].v : '';
+      document.getElementById('fechaInicio').textContent = row[2] ? row[2].v : '';
+      document.getElementById('contratista').textContent = row[3] ? row[3].v : '';
+      datosDiv.style.display = 'block';
+    } else {
+      alertEl.textContent = 'Expediente no encontrado. Verifique el número y los ceros adelante.';
+      alertEl.style.display = 'block';
+    }
+  } catch (e) {
+    alertEl.textContent = 'Error al buscar el expediente.';
+    alertEl.style.display = 'block';
+  }
+}

--- a/project.js
+++ b/project.js
@@ -236,7 +236,10 @@ function openPdfReport() {
         resultEl.style.wordSpacing = originalWordSpacing;
         const pdfBlob = doc.output('blob');
         const pdfUrl = URL.createObjectURL(pdfBlob);
-        window.open(pdfUrl, '_blank');
+        const newWin = window.open(pdfUrl, '_blank');
+        if (!newWin || newWin.closed || typeof newWin.closed === 'undefined') {
+          window.location.href = pdfUrl;
+        }
         setTimeout(() => URL.revokeObjectURL(pdfUrl), 1000);
       };
 

--- a/script.js
+++ b/script.js
@@ -310,7 +310,10 @@ function openPdfReport() {
         resultEl.style.wordSpacing = originalWordSpacing;
         const pdfBlob = doc.output('blob');
         const pdfUrl = URL.createObjectURL(pdfBlob);
-        window.open(pdfUrl, '_blank');
+        const newWin = window.open(pdfUrl, '_blank');
+        if (!newWin || newWin.closed || typeof newWin.closed === 'undefined') {
+          window.location.href = pdfUrl;
+        }
         setTimeout(() => URL.revokeObjectURL(pdfUrl), 1000);
       };
 

--- a/styles.css
+++ b/styles.css
@@ -10,14 +10,16 @@ body {
 
 .logo-container {
   background: rgb(1, 5, 10);
+  width: 100%;
   text-align: center;
-  padding: 10px;
+  padding: 10px 10px 40px;
   position: fixed;
   top: 0;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
   z-index: 1000;
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .logo {
@@ -67,6 +69,14 @@ h1 {
   width: 100%;
   margin: 0.5rem 0;
   text-transform: none;
+}
+
+.btn-paralizacion {
+  background: #cc5500;
+}
+
+.btn-paralizacion:hover {
+  background: #e66b00;
 }
 
 .menu button.coming-soon {
@@ -240,6 +250,11 @@ body.dark-mode #themeToggle {
   border: 1px solid #ffa94d;
   padding: 0.5rem;
   border-radius: 4px;
+  font-weight: bold;
+}
+
+.alert-error {
+  color: #a00;
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- Expand header to full width and adjust menu and theme buttons
- Add dark-orange “Solicitar Paralización (Próximamente)” menu option and form hooked to Google Sheets
- Improve PDF report generation to open in browser when popups are blocked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fa20e811c832ea1aa10ff70c9b178