### PR TITLE
Add inspector selection and adjudication fields

### DIFF
--- a/paralizacion.html
+++ b/paralizacion.html
@@ -28,6 +28,57 @@
       <p><strong>Obra:</strong> <span id="obraNombre"></span></p>
       <p><strong>Fecha de Inicio:</strong> <span id="fechaInicio"></span></p>
       <p><strong>Contratista:</strong> <span id="contratista"></span></p>
+      <label for="inspectores">Inspector/es a cargo:</label>
+      <select id="inspectores" multiple>
+        <option value="ADRIAN TROISI">ADRIAN TROISI</option>
+        <option value="APARICIO MIGUEL ANGEL">APARICIO MIGUEL ANGEL</option>
+        <option value="ARROYO MARIA CECILIA">ARROYO MARIA CECILIA</option>
+        <option value="CAPORALINI DANIEL">CAPORALINI DANIEL</option>
+        <option value="CARVAJAL GABRIEL">CARVAJAL GABRIEL</option>
+        <option value="COFRE MARCELA">COFRE MARCELA</option>
+        <option value="CRISTIAN TORRES">CRISTIAN TORRES</option>
+        <option value="DEL PIANO JAVIER">DEL PIANO JAVIER</option>
+        <option value="ESCALANTE WALTER">ESCALANTE WALTER</option>
+        <option value="EVA GONZALEZ">EVA GONZALEZ</option>
+        <option value="FERRARO ENZO">FERRARO ENZO</option>
+        <option value="GARCIA MARA BELEN">GARCIA MARA BELEN</option>
+        <option value="GUAHNON GUSTAVO">GUAHNON GUSTAVO</option>
+        <option value="HUGO HERNANDEZ">HUGO HERNANDEZ</option>
+        <option value="IDANEZ GUSTAVO">IDANEZ GUSTAVO</option>
+        <option value="INOSTROSA OSCAR">INOSTROSA OSCAR</option>
+        <option value="JUAN CALDENTEY">JUAN CALDENTEY</option>
+        <option value="LOPEZ BAEZA ORLANDO ARIEL">LOPEZ BAEZA ORLANDO ARIEL</option>
+        <option value="MAITA MELINA">MAITA MELINA</option>
+        <option value="MALINQUEO JUAN CARLOS">MALINQUEO JUAN CARLOS</option>
+        <option value="MARIA EUGENIA RAELE">MARIA EUGENIA RAELE</option>
+        <option value="MENDEZ CLAUDIO">MENDEZ CLAUDIO</option>
+        <option value="MOLINA SEBASTIAN">MOLINA SEBASTIAN</option>
+        <option value="MONDINO ADRIAN">MONDINO ADRIAN</option>
+        <option value="MONTORFANO FACUNDO">MONTORFANO FACUNDO</option>
+        <option value="ORTIGUEIRA FIORELLA">ORTIGUEIRA FIORELLA</option>
+        <option value="PEÑA HECTOR FABIAN">PEÑA HECTOR FABIAN</option>
+        <option value="PICHAUD MATIAS">PICHAUD MATIAS</option>
+        <option value="PRIETO RUBEN OSVALDO">PRIETO RUBEN OSVALDO</option>
+        <option value="RODRIGUEZ PABLO">RODRIGUEZ PABLO</option>
+        <option value="ROJAS LUCAS">ROJAS LUCAS</option>
+        <option value="SANTOS HUGO">SANTOS HUGO</option>
+        <option value="SCHMIDT SUSANA">SCHMIDT SUSANA</option>
+        <option value="SOLDANO RAMIRO">SOLDANO RAMIRO</option>
+        <option value="VASQUEZ EZEQUIEL">VASQUEZ EZEQUIEL</option>
+        <option value="VILLAGRA CARLOS IVAN">VILLAGRA CARLOS IVAN</option>
+        <option value="OTRO (Corregirlo después pero avisarle a la Dirección General de Certificaciones para agregarlo)">
+          OTRO (Corregirlo después pero avisarle a la Dirección General de Certificaciones para agregarlo)
+        </option>
+      </select>
+      <p>Adjudicada por:</p>
+      <div class="adjudicada-options">
+        <label><input type="radio" name="adjudicadaPor" value="Disposición"> Disposición</label>
+        <label><input type="radio" name="adjudicadaPor" value="Resolución"> Resolución</label>
+        <label><input type="radio" name="adjudicadaPor" value="Decreto"> Decreto</label>
+      </div>
+      <label for="numeroAdjudicacion">Número:</label>
+      <input type="text" id="numeroAdjudicacion" />
+      <small class="suggestion"><em>Formato solicitado "XX/202Y"</em></small>
       <label for="fechaSolicitud">Fecha de solicitud de paralización:</label>
       <input type="date" id="fechaSolicitud" />
       <label for="motivo">Motivo de la paralización:</label>

--- a/styles.css
+++ b/styles.css
@@ -128,6 +128,12 @@ select:focus {
   margin-top: 1.5rem;
 }
 
+.adjudicada-options label {
+  display: inline-block;
+  margin-top: 0;
+  margin-right: 1rem;
+}
+
 button {
   padding: 0.6rem 1.2rem;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- allow choosing one or more inspectors when requesting a paralización
- support specifying adjudication type and number in the paralización form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fae9dc634832e9c4e0f5c02534fd7