### PR TITLE
Implement doPost and update paralización Web App URL

### DIFF
--- a/paralizacion.gs
+++ b/paralizacion.gs
@@ -1,0 +1,19 @@
+function doPost(e) {
+  const ss = SpreadsheetApp.openById('1vwRWuYRmiAmw4FPKh7n-4t6W4mcWn_wSo8MlLJ9P0fk');
+  const sheet = ss.getSheetByName('Paralizacion') || ss.getActiveSheet();
+  const data = JSON.parse(e.postData.contents);
+  sheet.appendRow([
+    data.timestamp,
+    data.fechaSolicitud,
+    data.expediente,
+    data.inspectores,
+    data.tipoAlteracion,
+    data.obra,
+    data.contratista,
+    data.adjudicadaPor,
+    data.motivo
+  ]);
+  return ContentService.createTextOutput(
+    JSON.stringify({ result: 'success' })
+  ).setMimeType(ContentService.MimeType.JSON);
+}

--- a/paralizacion.js
+++ b/paralizacion.js
@@ -90,7 +90,7 @@ document.getElementById('solicitarBtn').addEventListener('click', async () => {
     adjudicadaPor,
     motivo
   };
-  const scriptURL = 'https://script.google.com/u/0/home/projects/1_DIdunfGd5v1mBTYRG8tP3hkoBcMFe7j03qGUvCgPFFiMO5FhPlfPXP-';
+  const scriptURL = 'https://script.google.com/macros/s/AKfycbw5nSq_t0NqjNLSNELEspuPmhzvYJL0OR_y1WWNo4wV49vD0o7gWDpN_Up8/exec';
 
   const successEl = document.getElementById('successMessage');
   const alertEl = document.getElementById('alert');


### PR DESCRIPTION
## Summary
- Add `doPost` Apps Script to parse incoming JSON and append rows to paralización sheet.
- Update `paralizacion.js` to use new deployed Web App endpoint.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fef4fe690832e8cc230b582883a52