### PR TITLE
feat: register paralizacion request

### DIFF
--- a/paralizacion.gs
+++ b/paralizacion.gs
@@ -1,6 +1,9 @@
+const SPREADSHEET_ID = '1vwRWuYRmiAmw4FPKh7n-4t6W4mcWn_wSo8MlLJ9P0fk';
+const SHEET_NAME = 'Respuestas_SParalización';
+
 function doPost(e) {
-  const ss = SpreadsheetApp.openById('1vwRWuYRmiAmw4FPKh7n-4t6W4mcWn_wSo8MlLJ9P0fk');
-  const sheet = ss.getSheetByName('Paralizacion') || ss.getActiveSheet();
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  const sheet = ss.getSheetByName(SHEET_NAME) || ss.getActiveSheet();
   const data = JSON.parse(e.postData.contents);
   sheet.appendRow([
     data.timestamp,

--- a/paralizacion.js
+++ b/paralizacion.js
@@ -105,7 +105,7 @@ document.getElementById('solicitarBtn').addEventListener('click', async () => {
     });
     if (res.ok) {
       if (successEl) {
-        successEl.textContent = '✅ Solicitud registrada. El documento se generará automáticamente en unos segundos.';
+        successEl.textContent = 'Solicitud registrada correctamente. El documento se generará automáticamente en unos segundos.';
         successEl.style.display = 'block';
       }
     } else if (alertEl) {


### PR DESCRIPTION
## Summary
- add timestamped paralizacion request submission
- allow configurability for sheet and sheet name

## Testing
- `node --check paralizacion.js`
- `cat paralizacion.gs | node --check`


------
https://chatgpt.com/codex/tasks/task_e_688ff24ef364832e8a6c3b222304b8af