### PR TITLE
Fix PDF report download

### DIFF
--- a/project.js
+++ b/project.js
@@ -236,10 +236,12 @@ function openPdfReport() {
         resultEl.style.wordSpacing = originalWordSpacing;
         const pdfBlob = doc.output('blob');
         const pdfUrl = URL.createObjectURL(pdfBlob);
-        const newWin = window.open(pdfUrl, '_blank');
-        if (!newWin || newWin.closed || typeof newWin.closed === 'undefined') {
-          window.location.href = pdfUrl;
-        }
+        const link = document.createElement('a');
+        link.href = pdfUrl;
+        link.download = 'informe.pdf';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
         setTimeout(() => URL.revokeObjectURL(pdfUrl), 1000);
       };
 

--- a/script.js
+++ b/script.js
@@ -310,10 +310,12 @@ function openPdfReport() {
         resultEl.style.wordSpacing = originalWordSpacing;
         const pdfBlob = doc.output('blob');
         const pdfUrl = URL.createObjectURL(pdfBlob);
-        const newWin = window.open(pdfUrl, '_blank');
-        if (!newWin || newWin.closed || typeof newWin.closed === 'undefined') {
-          window.location.href = pdfUrl;
-        }
+        const link = document.createElement('a');
+        link.href = pdfUrl;
+        link.download = 'informe.pdf';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
         setTimeout(() => URL.revokeObjectURL(pdfUrl), 1000);
       };
 


### PR DESCRIPTION
## Summary
- ensure PDF report downloads directly without opening a new tab in both calculators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e00b8a6c832eafdd1a58e0bb5b2d