### PR TITLE
feat: add pdf viewing and sharing

### DIFF
--- a/AndroidApp/app/build.gradle
+++ b/AndroidApp/app/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'com.android.application' version '8.0.2'
+}
+
+android {
+    namespace "com.example.certyapp"
+    compileSdkVersion 33
+
+    defaultConfig {
+        applicationId "com.example.certyapp"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.github.barteksc:android-pdf-viewer:3.2.0-beta.1'
+}

--- a/AndroidApp/app/src/main/AndroidManifest.xml
+++ b/AndroidApp/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.certyapp">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:label="CertyApp"

--- a/AndroidApp/app/src/main/java/com/example/certyapp/MainActivity.java
+++ b/AndroidApp/app/src/main/java/com/example/certyapp/MainActivity.java
@@ -7,30 +7,50 @@ import android.graphics.Paint;
 import android.graphics.pdf.PdfDocument;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.FileProvider;
 import android.view.View;
 import android.widget.Button;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.FileProvider;
+
+import com.github.barteksc.pdfviewer.PDFView;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class MainActivity extends AppCompatActivity {
+
+    private PDFView pdfView;
+    private File currentPdfFile;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        pdfView = findViewById(R.id.pdfView);
         Button printButton = findViewById(R.id.printButton);
+        Button shareButton = findViewById(R.id.shareButton);
+
         printButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 try {
-                    File pdfFile = generatePdf();
-                    openPdf(pdfFile);
+                    currentPdfFile = generatePdf();
+                    pdfView.fromFile(currentPdfFile).load();
+                    openPdf(currentPdfFile);
                 } catch (IOException e) {
                     e.printStackTrace();
+                }
+            }
+        });
+
+        shareButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (currentPdfFile != null) {
+                    sharePdf(currentPdfFile);
                 }
             }
         });
@@ -67,7 +87,16 @@ public class MainActivity extends AppCompatActivity {
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setDataAndType(uri, "application/pdf");
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        startActivity(intent);
+        startActivity(Intent.createChooser(intent, "Abrir PDF"));
+    }
+
+    private void sharePdf(File pdfFile) {
+        Uri uri = FileProvider.getUriForFile(this, BuildConfig.APPLICATION_ID + ".provider", pdfFile);
+        Intent shareIntent = new Intent(Intent.ACTION_SEND);
+        shareIntent.setType("application/pdf");
+        shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        startActivity(Intent.createChooser(shareIntent, "Compartir PDF"));
     }
 }
 

--- a/AndroidApp/app/src/main/res/layout/activity_main.xml
+++ b/AndroidApp/app/src/main/res/layout/activity_main.xml
@@ -3,12 +3,23 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:gravity="center"
     android:padding="16dp">
 
     <Button
         android:id="@+id/printButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Imprimir informe en PDF" />
+        android:text="Imprimir PDF" />
+
+    <Button
+        android:id="@+id/shareButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Compartir PDF" />
+
+    <com.github.barteksc.pdfviewer.PDFView
+        android:id="@+id/pdfView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 </LinearLayout>

--- a/AndroidApp/settings.gradle
+++ b/AndroidApp/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+include ':app'


### PR DESCRIPTION
## Summary
- add AndroidPdfViewer-based PDF viewer and sharing
- enable PDF sharing via FileProvider
- configure Gradle and manifest for PDF support

## Testing
- `gradle tasks` *(fails: Plugin [id: 'com.android.application', version: '8.0.2'] not found)*

------
https://chatgpt.com/codex/tasks/task_e_689163b045b8832ea13e024e09052def