### PR TITLE
feat: upload PDF to server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+uploads/
+AndroidApp/.gradle/
+AndroidApp/build/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "certy_app",
+  "version": "1.0.0",
+  "description": "Certy App server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5"
+  }
+}

--- a/project.js
+++ b/project.js
@@ -225,7 +225,7 @@ function openPdfReport() {
       doc.setFont('helvetica', 'italic');
       doc.setTextColor(0, 0, 0);
 
-      const finalize = () => {
+      const finalize = async () => {
         for (let el in originalStyles) {
           if (el.style) {
             el.style.color = originalStyles[el].color;
@@ -234,15 +234,20 @@ function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
+
         const pdfBlob = doc.output('blob');
-        const pdfUrl = URL.createObjectURL(pdfBlob);
-        const link = document.createElement('a');
-        link.href = pdfUrl;
-        link.download = 'informe.pdf';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        setTimeout(() => URL.revokeObjectURL(pdfUrl), 1000);
+        const formData = new FormData();
+        formData.append('file', pdfBlob, 'informe.pdf');
+
+        try {
+          const response = await fetch('/pdf', { method: 'POST', body: formData });
+          if (!response.ok) throw new Error('Error en la carga del PDF');
+          const { url } = await response.json();
+          window.open(url, '_blank');
+        } catch (err) {
+          console.error('Error generando o enviando el PDF:', err);
+          alert('No se pudo generar el PDF.');
+        }
       };
 
       const img = new Image();

--- a/script.js
+++ b/script.js
@@ -299,7 +299,7 @@ function openPdfReport() {
       doc.setFont('helvetica', 'italic');
       doc.setTextColor(0, 0, 0); // Black text
 
-      const finalize = () => {
+      const finalize = async () => {
         for (let el in originalStyles) {
           if (el.style) {
             el.style.color = originalStyles[el].color;
@@ -308,15 +308,20 @@ function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
+
         const pdfBlob = doc.output('blob');
-        const pdfUrl = URL.createObjectURL(pdfBlob);
-        const link = document.createElement('a');
-        link.href = pdfUrl;
-        link.download = 'informe.pdf';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        setTimeout(() => URL.revokeObjectURL(pdfUrl), 1000);
+        const formData = new FormData();
+        formData.append('file', pdfBlob, 'informe.pdf');
+
+        try {
+          const response = await fetch('/pdf', { method: 'POST', body: formData });
+          if (!response.ok) throw new Error('Error en la carga del PDF');
+          const { url } = await response.json();
+          window.open(url, '_blank');
+        } catch (err) {
+          console.error('Error generando o enviando el PDF:', err);
+          alert('No se pudo generar el PDF.');
+        }
       };
 
       const img = new Image();

--- a/server.js
+++ b/server.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const app = express();
+const uploadDir = path.join(__dirname, 'uploads');
+
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir);
+}
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => cb(null, Date.now() + '-' + file.originalname)
+});
+
+const upload = multer({ storage });
+
+app.post('/pdf', upload.single('file'), (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'No file uploaded' });
+    }
+    const fileUrl = `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`;
+    res.json({ url: fileUrl });
+  } catch (err) {
+    console.error('Error processing PDF upload:', err);
+    res.status(500).json({ error: 'Error al procesar el PDF' });
+  }
+});
+
+app.use('/uploads', express.static(uploadDir));
+
+app.use((err, req, res, next) => {
+  console.error('Server error:', err);
+  res.status(500).json({ error: 'Server error' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- send generated PDFs to server instead of direct download
- expose `/pdf` endpoint to store uploaded reports and return public URLs
- add ignores for build artifacts and dependencies

## Testing
- `npm install express multer --no-audit --no-fund` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68917411e30c832e8dc96112f329ba83