### PR TITLE
Detect Android WebView and offload PDF generation

### DIFF
--- a/common.js
+++ b/common.js
@@ -20,3 +20,10 @@ function installApp() {
   document.body.classList.add('big-text');
   window.open('https://lucerodamian88.github.io/Certy_app/download.html', '_blank');
 }
+
+function isAndroidWebView() {
+  const ua = navigator.userAgent || '';
+  return /Android/.test(ua) && /; wv\)/.test(ua);
+}
+
+window.isAndroidWebView = isAndroidWebView;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "multer": "^1.4.5"
+    "multer": "^1.4.5-lts.1"
   }
 }

--- a/project.js
+++ b/project.js
@@ -182,10 +182,28 @@ function clearAll() {
   document.getElementById('printBtn').style.display = 'none';
 }
 
-function openPdfReport() {
+async function openPdfReport() {
+  const resultEl = document.getElementById('result');
+
+  if (window.isAndroidWebView && window.isAndroidWebView()) {
+    try {
+      const response = await fetch('/generate-pdf', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ html: resultEl.innerHTML })
+      });
+      if (!response.ok) throw new Error('Error en la generación del PDF');
+      const { url } = await response.json();
+      window.open(url, '_blank');
+    } catch (err) {
+      console.error('Error generando PDF en el servidor:', err);
+      alert('No se pudo generar el PDF.');
+    }
+    return;
+  }
+
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
-  const resultEl = document.getElementById('result');
   const originalWordSpacing = resultEl.style.wordSpacing;
   const textNodes = [];
   const walker = document.createTreeWalker(resultEl, NodeFilter.SHOW_TEXT, null, false);

--- a/script.js
+++ b/script.js
@@ -255,10 +255,28 @@ function clearAll() {
     document.getElementById('printBtn').style.display = 'none';
 }
 
-function openPdfReport() {
+async function openPdfReport() {
+  const resultEl = document.getElementById('result');
+
+  if (window.isAndroidWebView && window.isAndroidWebView()) {
+    try {
+      const response = await fetch('/generate-pdf', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ html: resultEl.innerHTML })
+      });
+      if (!response.ok) throw new Error('Error en la generación del PDF');
+      const { url } = await response.json();
+      window.open(url, '_blank');
+    } catch (err) {
+      console.error('Error generando PDF en el servidor:', err);
+      alert('No se pudo generar el PDF.');
+    }
+    return;
+  }
+
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
-  const resultEl = document.getElementById('result');
   const originalWordSpacing = resultEl.style.wordSpacing;
   const textNodes = [];
   const walker = document.createTreeWalker(resultEl, NodeFilter.SHOW_TEXT, null, false);

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 
 const app = express();
 const uploadDir = path.join(__dirname, 'uploads');
+app.use(express.json({ limit: '5mb' }));
 
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir);
@@ -27,6 +28,51 @@ app.post('/pdf', upload.single('file'), (req, res) => {
   } catch (err) {
     console.error('Error processing PDF upload:', err);
     res.status(500).json({ error: 'Error al procesar el PDF' });
+  }
+});
+
+app.post('/generate-pdf', (req, res) => {
+  try {
+    const { html } = req.body || {};
+    if (!html) {
+      return res.status(400).json({ error: 'No HTML provided' });
+    }
+    const text = html.replace(/<[^>]+>/g, '');
+    const fileName = `${Date.now()}.pdf`;
+    const filePath = path.join(uploadDir, fileName);
+
+    const escapePdf = s => s.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)').replace(/\r?\n/g, '\\n');
+    const content = escapePdf(text);
+
+    const header = '%PDF-1.3\n';
+    const obj1 = '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n';
+    const obj2 = '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n';
+    const obj3 = '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>\nendobj\n';
+    const streamStr = `BT /F1 12 Tf 50 800 Td (${content}) Tj ET`;
+    const obj4 = `4 0 obj\n<< /Length ${streamStr.length} >>\nstream\n${streamStr}\nendstream\nendobj\n`;
+    const obj5 = '5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n';
+    const objects = [obj1, obj2, obj3, obj4, obj5];
+
+    let pdf = header;
+    const offsets = [0];
+    objects.forEach(obj => {
+      offsets.push(pdf.length);
+      pdf += obj;
+    });
+    const xrefPos = pdf.length;
+    pdf += 'xref\n0 6\n';
+    pdf += '0000000000 65535 f \n';
+    for (let i = 1; i <= 5; i++) {
+      pdf += offsets[i].toString().padStart(10, '0') + ' 00000 n \n';
+    }
+    pdf += 'trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n' + xrefPos + '\n%%EOF';
+
+    fs.writeFileSync(filePath, pdf);
+    const fileUrl = `${req.protocol}://${req.get('host')}/uploads/${fileName}`;
+    res.json({ url: fileUrl });
+  } catch (err) {
+    console.error('Error generating PDF:', err);
+    res.status(500).json({ error: 'Error generando el PDF' });
   }
 });
 


### PR DESCRIPTION
## Summary
- Detect Android WebView and skip client-side html2pdf usage
- Add server endpoint to create PDF from HTML and return a sharable URL
- Use server-side PDF generation when WebView is detected

## Testing
- `npm install --no-package-lock` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_689177caf480832eb7452eae2054e4c0