### PR TITLE
Fix PDF style restoration for web reports

### DIFF
--- a/project.js
+++ b/project.js
@@ -216,14 +216,14 @@ async function openPdfReport() {
   }
   resultEl.style.wordSpacing = '4px';
 
-  const originalStyles = {};
+  const originalStyles = new Map();
   const elements = resultEl.getElementsByTagName('*');
   for (let el of elements) {
     if (el.style) {
-      originalStyles[el] = {
+      originalStyles.set(el, {
         color: el.style.color,
         backgroundColor: el.style.backgroundColor
-      };
+      });
       el.style.color = '#000000';
       el.style.backgroundColor = '#FFFFFF';
     }
@@ -244,11 +244,9 @@ async function openPdfReport() {
       doc.setTextColor(0, 0, 0);
 
       const finalize = async () => {
-        for (let el in originalStyles) {
-          if (el.style) {
-            el.style.color = originalStyles[el].color;
-            el.style.backgroundColor = originalStyles[el].backgroundColor;
-          }
+        for (const [el, styles] of originalStyles.entries()) {
+          el.style.color = styles.color;
+          el.style.backgroundColor = styles.backgroundColor;
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;

--- a/script.js
+++ b/script.js
@@ -289,15 +289,15 @@ async function openPdfReport() {
   }
   resultEl.style.wordSpacing = '4px';
 
-  // Save original styles
-  const originalStyles = {};
+  // Save original styles using a Map to restore them later
+  const originalStyles = new Map();
   const elements = resultEl.getElementsByTagName('*');
   for (let el of elements) {
     if (el.style) {
-      originalStyles[el] = {
+      originalStyles.set(el, {
         color: el.style.color,
         backgroundColor: el.style.backgroundColor
-      };
+      });
       el.style.color = '#000000';
       el.style.backgroundColor = '#FFFFFF';
     }
@@ -318,11 +318,9 @@ async function openPdfReport() {
       doc.setTextColor(0, 0, 0); // Black text
 
       const finalize = async () => {
-        for (let el in originalStyles) {
-          if (el.style) {
-            el.style.color = originalStyles[el].color;
-            el.style.backgroundColor = originalStyles[el].backgroundColor;
-          }
+        for (const [el, styles] of originalStyles.entries()) {
+          el.style.color = styles.color;
+          el.style.backgroundColor = styles.backgroundColor;
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;


### PR DESCRIPTION
## Summary
- Preserve and restore original element styles during client-side PDF generation.
- Ensures the web page retains its formatting after printing reports.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689238420a98832eb9bcbe97748bdbff