### PR TITLE
Add CORS header to Google Apps Script

### DIFF
--- a/paralizacion.gs
+++ b/paralizacion.gs
@@ -18,5 +18,7 @@ function doPost(e) {
   ]);
   return ContentService.createTextOutput(
     JSON.stringify({ result: 'success' })
-  ).setMimeType(ContentService.MimeType.JSON);
+  )
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader("Access-Control-Allow-Origin", "*");
 }


### PR DESCRIPTION
## Summary
- Add Access-Control-Allow-Origin header to Apps Script response so client requests are allowed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "fetch('https://script.google.com/macros/s/AKfycbw5nSq_t0NqjNLSNELEspuPmhzvYJL0OR_y1WWNo4wV49vD0o7gWDpN_Up8/exec',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({test:'data'})}).then(async res=>{console.log('status',res.status); console.log('ok',res.ok); const text=await res.text(); console.log('body',text.slice(0,200));}).catch(err=>{console.error('error',err);});"` *(fails: fetch failed: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68926cdbfbdc832e850d29f4f68f9f9d