### PR TITLE
Send paralización form data to Apps Script

### DIFF
--- a/paralizacion.html
+++ b/paralizacion.html
@@ -24,7 +24,7 @@
       <button onclick="buscarExpediente()">BUSCAR</button>
     </div>
     <div id="alert" class="alert-error" style="display:none;"></div>
-    <div id="datosObra" style="display:none;">
+    <form id="formularioParalizacion" style="display:none;">
       <p><strong>Obra:</strong> <span id="obraNombre"></span></p>
       <p><strong>Fecha de Inicio:</strong> <span id="fechaInicio"></span></p>
       <p><strong>Contratista:</strong> <span id="contratista"></span></p>
@@ -44,10 +44,10 @@
       <textarea id="motivo" rows="4"></textarea>
       <small class="suggestion justify-text">En esta instancia no es necesario explayarse en el motivo, ya que es solo para la apertura del expediente. <em>Ejemplo: El motivo que justifica dicha paralización radica en los plazos pendientes de aprobación del proyecto ejecutivo presentado en CALF por parte de la empresa contratista, así como en dificultades vinculadas a la adquisición de materiales.</em></small>
       <div class="button-row">
-        <button id="solicitarBtn">SOLICITAR</button>
+        <button id="solicitarBtn" type="submit">SOLICITAR</button>
       </div>
       <div id="successMessage" class="alert-success" style="display:none;"></div>
-    </div>
+    </form>
   </div>
 
   <script src="common.js"></script>

--- a/paralizacion.js
+++ b/paralizacion.js
@@ -33,7 +33,7 @@ function formatearFecha(valor) {
 async function buscarExpediente() {
   const exp = document.getElementById('expedienteInput').value.trim();
   const alertEl = document.getElementById('alert');
-  const datosDiv = document.getElementById('datosObra');
+  const datosDiv = document.getElementById('formularioParalizacion');
   alertEl.style.display = 'none';
   datosDiv.style.display = 'none';
   if (!exp) return;
@@ -66,56 +66,64 @@ async function buscarExpediente() {
   }
 }
 
-document.getElementById('solicitarBtn').addEventListener('click', async () => {
-  const fechaSolicitud = document.getElementById('fechaSolicitud').value;
-  const expediente = document.getElementById('expedienteInput').value.trim();
-  const inspectores = document.getElementById('inspectoresEncontrados').textContent;
-  const tipoAlteracion = 'Paralización';
-  const obra = document.getElementById('obraNombre').textContent;
-  const contratista = document.getElementById('contratista').textContent;
-  const adjudicadaPorTipo = document.getElementById('adjudicadaPor').value;
-  const numeroAdjudicacion = document.getElementById('numeroAdjudicacion').value.trim();
-  const adjudicadaPor = adjudicadaPorTipo ? `${adjudicadaPorTipo} ${numeroAdjudicacion}` : '';
-  const motivo = document.getElementById('motivo').value.trim();
-  const timestamp = new Date().toLocaleString('es-AR');
+const formulario = document.getElementById('formularioParalizacion');
+if (formulario) {
+  formulario.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fechaSolicitud = document.getElementById('fechaSolicitud').value;
+    const expediente = document.getElementById('expedienteInput').value.trim();
+    const inspectores = document.getElementById('inspectoresEncontrados').textContent;
+    const tipoAlteracion = 'Paralización';
+    const nombreObra = document.getElementById('obraNombre').textContent;
+    const empresa = document.getElementById('contratista').textContent;
+    const adjudicadaPorTipo = document.getElementById('adjudicadaPor').value;
+    const numeroAdjudicacion = document.getElementById('numeroAdjudicacion').value.trim();
+    const adjudicadaPor = adjudicadaPorTipo ? `${adjudicadaPorTipo} ${numeroAdjudicacion}` : '';
+    const motivo = document.getElementById('motivo').value.trim();
 
-  const data = {
-    timestamp,
-    fechaSolicitud,
-    expediente,
-    inspectores,
-    tipoAlteracion,
-    obra,
-    contratista,
-    adjudicadaPor,
-    motivo
-  };
-  const scriptURL = 'https://script.google.com/macros/s/AKfycbw5nSq_t0NqjNLSNELEspuPmhzvYJL0OR_y1WWNo4wV49vD0o7gWDpN_Up8/exec';
+    const data = {
+      fechaSolicitud,
+      expediente,
+      inspectores,
+      tipoAlteracion,
+      nombreObra,
+      empresa,
+      adjudicadaPor,
+      motivo
+    };
+    const scriptURL = 'https://script.google.com/macros/s/AKfycbxy6wkCltPw3nKW35c9IyGmmcFn5jeAoJ2t2V4dqc-F892XUFtGjTi2tFWCM3swNvTO/exec';
 
-  const successEl = document.getElementById('successMessage');
-  const alertEl = document.getElementById('alert');
-  if (successEl) successEl.style.display = 'none';
-  if (alertEl) alertEl.style.display = 'none';
+    const successEl = document.getElementById('successMessage');
+    const alertEl = document.getElementById('alert');
+    if (successEl) successEl.style.display = 'none';
+    if (alertEl) alertEl.style.display = 'none';
 
-  try {
-    const res = await fetch(scriptURL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
-    });
-    if (res.ok) {
-      if (successEl) {
-        successEl.textContent = 'Solicitud registrada correctamente. El documento se generará automáticamente en unos segundos.';
-        successEl.style.display = 'block';
+    try {
+      const res = await fetch(scriptURL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (res.ok) {
+        if (successEl) {
+          successEl.textContent = 'Formulario enviado correctamente.';
+          successEl.style.display = 'block';
+        }
+        formulario.reset();
+        document.getElementById('expedienteInput').value = '';
+        document.getElementById('obraNombre').textContent = '';
+        document.getElementById('fechaInicio').textContent = '';
+        document.getElementById('contratista').textContent = '';
+        document.getElementById('inspectoresEncontrados').textContent = '';
+      } else if (alertEl) {
+        alertEl.textContent = 'Error al enviar el formulario.';
+        alertEl.style.display = 'block';
       }
-    } else if (alertEl) {
-      alertEl.textContent = 'Error al registrar la solicitud.';
-      alertEl.style.display = 'block';
+    } catch (e) {
+      if (alertEl) {
+        alertEl.textContent = 'Error al enviar el formulario.';
+        alertEl.style.display = 'block';
+      }
     }
-  } catch (e) {
-    if (alertEl) {
-      alertEl.textContent = 'Error al registrar la solicitud.';
-      alertEl.style.display = 'block';
-    }
-  }
-});
+  });
+}


### PR DESCRIPTION
## Summary
- wrap paralización inputs in `formularioParalizacion` and add submit button
- send form fields as JSON via POST to new Apps Script and handle responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check paralizacion.js`


------
https://chatgpt.com/codex/tasks/task_e_689276169bc4832eb147178036c90002