### PR TITLE
feat: show success notification on paralizacion

### DIFF
--- a/paralizacion.html
+++ b/paralizacion.html
@@ -24,6 +24,7 @@
       <button onclick="buscarExpediente()">BUSCAR</button>
     </div>
     <div id="alert" class="alert-error" style="display:none;"></div>
+    <div id="successMessage" class="alert-success" style="display:none;"></div>
     <form id="formularioParalizacion" style="display:none;">
       <p><strong>Obra:</strong> <span id="obraNombre"></span></p>
       <p><strong>Fecha de Inicio:</strong> <span id="fechaInicio"></span></p>
@@ -55,14 +56,18 @@
   document.getElementById('formularioParalizacion').addEventListener('submit', async function (event) {
     event.preventDefault();
 
+    const successEl = document.getElementById('successMessage');
+    successEl.style.display = 'none';
+
+    const adjudicadaPor = `${document.getElementById('adjudicadaPor').value.trim()} N° ${document.getElementById('numeroAdjudicacion').value.trim()}`;
     const datos = {
       numeroExpediente: document.getElementById('expedienteInput').value.trim(),
       nombreObra: document.getElementById('obraNombre').textContent.trim(),
       fechaInicio: document.getElementById('fechaInicio').textContent.trim(),
       empresaContratista: document.getElementById('contratista').textContent.trim(),
       inspectores: document.getElementById('inspectoresEncontrados').textContent.trim(),
-      adjudicadaPor: document.getElementById('adjudicadaPor').value.trim(),
-      numeroAdjudicacion: document.getElementById('numeroAdjudicacion').value.trim(),
+      tipoAlteracion: 'paralización',
+      adjudicadaPor,
       fechaSolicitud: document.getElementById('fechaSolicitud').value,
       motivo: document.getElementById('motivo').value.trim()
     };
@@ -89,7 +94,9 @@
       try { result = JSON.parse(text); } catch { result = { success: false, error: 'Respuesta no válida del servidor' }; }
 
       if (result.success) {
-        alert('Solicitud enviada correctamente.');
+        successEl.innerHTML = '&#10004; Tu solicitud fue registrada';
+        successEl.style.display = 'block';
+        setTimeout(() => { successEl.style.display = 'none'; }, 3000);
         this.reset();
         document.getElementById('expedienteInput').value = '';
         this.style.display = 'none';


### PR DESCRIPTION
## Summary
- show temporary success banner with green check after submitting paralización form
- combine adjudication type and number into one field and send constant tipoAlteracion="paralización"

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689566e82860832e87dc2b0ec12e43b3