### PR TITLE
Add drafting suggestion modal using OpenAI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Certy App server",
   "main": "server.js",
   "scripts": {
+    "prestart": "node -e \"if(!process.env.OPENAI_API_KEY){console.error('OPENAI_API_KEY no configurada');process.exit(1)}\"",
     "start": "node server.js"
   },
   "dependencies": {
     "express": "^4.18.2",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "openai": "^4.47.0"
   }
 }

--- a/paralizacion.html
+++ b/paralizacion.html
@@ -43,11 +43,22 @@
       <input type="date" id="fechaSolicitud" />
       <label for="motivo">Motivo de la paralización:</label>
       <textarea id="motivo" rows="4"></textarea>
+      <button type="button" id="sugerenciaBtn">Sugerencia de redacción</button>
       <small class="suggestion justify-text">En esta instancia no es necesario explayarse en el motivo, ya que es solo para la apertura del expediente. <em>Ejemplo: El motivo que justifica dicha paralización radica en los plazos pendientes de aprobación del proyecto ejecutivo presentado en CALF por parte de la empresa contratista, así como en dificultades vinculadas a la adquisición de materiales.</em></small>
       <div class="button-row">
         <button id="solicitarBtn" type="submit">SOLICITAR</button>
       </div>
     </form>
+  </div>
+
+  <div id="modalSugerencia" class="modal" hidden>
+    <div class="modal-content">
+      <p id="sugerenciaTexto"></p>
+      <div class="modal-buttons">
+        <button type="button" id="aceptarSugerencia">Aceptar</button>
+        <button type="button" id="rechazarSugerencia">Rechazar</button>
+      </div>
+    </div>
   </div>
 
   <script src="common.js"></script>

--- a/paralizacion.js
+++ b/paralizacion.js
@@ -3,6 +3,23 @@ window.addEventListener('DOMContentLoaded', () => {
   if (container) {
     container.classList.add('loaded');
   }
+
+  const sugerenciaBtn = document.getElementById('sugerenciaBtn');
+  const aceptarBtn = document.getElementById('aceptarSugerencia');
+  const rechazarBtn = document.getElementById('rechazarSugerencia');
+  if (sugerenciaBtn) {
+    sugerenciaBtn.addEventListener('click', solicitarSugerencia);
+  }
+  if (aceptarBtn && rechazarBtn) {
+    aceptarBtn.addEventListener('click', () => {
+      const texto = document.getElementById('sugerenciaTexto').textContent;
+      document.getElementById('motivo').value = texto;
+      document.getElementById('modalSugerencia').hidden = true;
+    });
+    rechazarBtn.addEventListener('click', () => {
+      document.getElementById('modalSugerencia').hidden = true;
+    });
+  }
 });
 
 function formatearFecha(valor) {
@@ -64,5 +81,28 @@ async function buscarExpediente() {
     alertEl.textContent = 'Error al buscar el expediente.';
     alertEl.style.display = 'block';
   }
+}
+
+async function solicitarSugerencia() {
+  const motivo = document.getElementById('motivo').value.trim();
+  const modal = document.getElementById('modalSugerencia');
+  const textoEl = document.getElementById('sugerenciaTexto');
+  const prompt = 'Corrige ortografía y gramática, y mejora la redacción manteniendo el sentido original, usando un tono formal y administrativo.';
+  try {
+    const res = await fetch('/sugerencia-redaccion', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ texto: motivo, prompt })
+    });
+    const data = await res.json();
+    if (data.sugerencia) {
+      textoEl.textContent = data.sugerencia;
+    } else {
+      textoEl.textContent = data.error || 'No se pudo obtener la sugerencia, intente nuevamente.';
+    }
+  } catch (err) {
+    textoEl.textContent = 'No se pudo obtener la sugerencia, intente nuevamente.';
+  }
+  modal.hidden = false;
 }
 

--- a/server.js
+++ b/server.js
@@ -2,10 +2,12 @@ const express = require('express');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const OpenAI = require('openai');
 
 const app = express();
 const uploadDir = path.join(__dirname, 'uploads');
 app.use(express.json({ limit: '5mb' }));
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir);
@@ -73,6 +75,25 @@ app.post('/generate-pdf', (req, res) => {
   } catch (err) {
     console.error('Error generating PDF:', err);
     res.status(500).json({ error: 'Error generando el PDF' });
+  }
+});
+
+app.post('/sugerencia-redaccion', async (req, res) => {
+  try {
+    const { texto, prompt } = req.body || {};
+    if (!texto) {
+      return res.status(400).json({ error: 'Texto requerido' });
+    }
+    const basePrompt = prompt || 'Corrige ortografía y gramática, y mejora la redacción manteniendo el sentido original, usando un tono formal y administrativo.';
+    const response = await openai.responses.create({
+      model: 'gpt-4o-mini',
+      input: `${basePrompt}\n\n${texto}`
+    });
+    const sugerencia = response.output_text;
+    res.json({ sugerencia });
+  } catch (err) {
+    console.error('Error solicitando sugerencia:', err);
+    res.status(500).json({ error: 'No se pudo obtener la sugerencia, intente nuevamente.' });
   }
 });
 

--- a/styles.css
+++ b/styles.css
@@ -278,6 +278,39 @@ body.dark-mode #themeToggle {
   font-weight: bold;
 }
 
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  max-width: 90%;
+  width: 400px;
+  text-align: center;
+}
+
+#sugerenciaTexto {
+  white-space: pre-wrap;
+  text-align: left;
+  margin-bottom: 1rem;
+}
+
+.modal-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
 @media (max-width: 480px) {
   body {
     padding-top: 90px;


### PR DESCRIPTION
## Summary
- Add "Sugerencia de redacción" button and modal to paralización form
- Style and script modal, fetching OpenAI suggestion via new endpoint
- Integrate OpenAI on server with `/sugerencia-redaccion` API and check for API key

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689569d0ecc8832e893a0d14572ba415