### PR TITLE
Refine paralizacion form layout and suggestions

### DIFF
--- a/paralizacion.html
+++ b/paralizacion.html
@@ -18,9 +18,9 @@
     <h1>Solicitar Paralización</h1>
       <label>N° de expediente:</label>
       <div class="expediente-input">
-        <input type="text" id="expedienteNumero" class="exp-number" />
+        <input type="text" id="expedienteNumero" class="exp-number" maxlength="6" size="6" />
         <span>-M-202</span>
-        <input type="text" id="expedienteAnio" class="exp-year" maxlength="1" />
+        <input type="text" id="expedienteAnio" class="exp-year" maxlength="1" size="1" />
       </div>
       <small class="suggestion"><em>Ej: 00125-M-2025</em></small>
     <div class="button-row">
@@ -73,8 +73,9 @@
         <div class="button-row">
           <button id="generarSugerencia" type="button" class="sugerencia-btn">Generar</button>
         </div>
-        <label for="textoSugerido">Texto sugerido por Certy. <strong>No olvides editarlo, copiarlo y pegarlo en "Motivo de la paralización" mas arriba</strong></label>
-        <textarea id="textoSugerido" rows="4"></textarea>
+        <label for="textoSugerido">Texto sugerido por Certy! <img src="Robot.png" alt="Robot" class="robot-icon" /></label>
+        <p class="suggestion-note"><strong><em>No olvides editarlo, copiarlo y pegarlo en "Motivo de la paralización" mas arriba 👆</em></strong></p>
+        <textarea id="textoSugerido" rows="6"></textarea>
       </div>
       <div class="button-row">
         <button id="solicitarBtn" type="submit">SOLICITAR</button>

--- a/styles.css
+++ b/styles.css
@@ -110,8 +110,10 @@ select {
   gap: 0.25rem;
 }
 
+
 .expediente-input .exp-number {
-  flex: 1;
+  flex: 0 0 auto;
+  width: 6ch;
 }
 
 .expediente-input span {
@@ -119,18 +121,33 @@ select {
 }
 
 .expediente-input .exp-year {
-  width: 2rem;
+  flex: 0 0 auto;
+  width: 2ch;
 }
 
 .radio-option {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.1rem;
   margin-top: 0.5rem;
+}
+
+.radio-option label {
+  white-space: nowrap;
 }
 
 #textoSugerido {
   width: 100%;
+}
+
+.robot-icon {
+  width: 1em;
+  height: 1em;
+  vertical-align: middle;
+}
+
+.suggestion-note {
+  white-space: nowrap;
 }
 
 .half-width {


### PR DESCRIPTION
## Summary
- Resize expediente fields for clearer input
- Tighten radio button layout and keep labels on one line
- Revise suggested text section with robot icon, reminder note, and larger preview box

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6897dcd75dec832ea63af0c8cf4bb989