### PR TITLE
Improve paralization form UX and export summary

### DIFF
--- a/paralizacion.gs
+++ b/paralizacion.gs
@@ -4,20 +4,21 @@ const SHEET_NAME = 'Respuestas_SParalización';
 function doPost(e) {
   const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
   const sheet = ss.getSheetByName(SHEET_NAME) || ss.getActiveSheet();
-  const data = JSON.parse(e.postData.contents);
+  const p = e.parameter;
   sheet.appendRow([
-    data.timestamp,
-    data.fechaSolicitud,
-    data.expediente,
-    data.inspectores,
-    data.tipoAlteracion,
-    data.obra,
-    data.contratista,
-    data.adjudicadaPor,
-    data.motivo
+    new Date(),
+    p.fechaSolicitud || '',
+    p.numeroExpediente || '',
+    p.inspectores || '',
+    p.tipoAlteracion || '',
+    p.nombreObra || '',
+    p.empresaContratista || '',
+    p.adjudicadaPor || '',
+    p.motivo || '',
+    p.motivoResumido || ''
   ]);
   return ContentService.createTextOutput(
-    JSON.stringify({ result: 'success' })
+    JSON.stringify({ success: true })
   )
     .setMimeType(ContentService.MimeType.JSON)
     .setHeader("Access-Control-Allow-Origin", "*");

--- a/paralizacion.html
+++ b/paralizacion.html
@@ -49,6 +49,7 @@
       <small class="suggestion justify-text">En esta instancia no es necesario explayarse en el motivo, ya que es solo para la apertura del expediente. <em>Ejemplo: El motivo que justifica dicha paralización radica en los plazos pendientes de aprobación del proyecto ejecutivo presentado en CALF por parte de la empresa contratista, así como en dificultades vinculadas a la adquisición de materiales.</em></small>
       <div class="button-row">
         <button id="sugerenciaBtn" type="button" class="sugerencia-btn">Sugerencia de redacción</button>
+        <button id="colapsarSugerenciaBtn" type="button" class="collapse-btn" style="display:none;">&#8593;</button>
       </div>
       <div id="sugerenciaSection" style="display:none;">
         <p>Seleccione una opción:</p>
@@ -88,14 +89,30 @@
   <script>
   const sugerenciaBtn = document.getElementById('sugerenciaBtn');
   const sugerenciaSection = document.getElementById('sugerenciaSection');
+  const colapsarBtn = document.getElementById('colapsarSugerenciaBtn');
   const opcionRadios = document.querySelectorAll('input[name="opcionSugerencia"]');
   const inputOpcion1 = document.getElementById('inputOpcion1');
   const inputOpcion2 = document.getElementById('inputOpcion2');
   const generarBtn = document.getElementById('generarSugerencia');
   const textoSugerido = document.getElementById('textoSugerido');
+  const motivo = document.getElementById('motivo');
+
+  function autoResize() {
+    this.style.height = 'auto';
+    this.style.height = this.scrollHeight + 'px';
+  }
+
+  motivo.addEventListener('input', autoResize);
+  autoResize.call(motivo);
 
   sugerenciaBtn.addEventListener('click', () => {
     sugerenciaSection.style.display = 'block';
+    colapsarBtn.style.display = 'inline-block';
+  });
+
+  colapsarBtn.addEventListener('click', () => {
+    sugerenciaSection.style.display = 'none';
+    colapsarBtn.style.display = 'none';
   });
 
   opcionRadios.forEach(radio => {

--- a/styles.css
+++ b/styles.css
@@ -162,6 +162,8 @@ select {
 
 #motivo {
   width: 100%;
+  background-color: #e6f7ff;
+  overflow-y: hidden;
 }
 
 input:focus,
@@ -202,6 +204,14 @@ button:hover {
 
 .sugerencia-btn:hover {
   background: #218838;
+}
+
+.collapse-btn {
+  background: #007bff;
+}
+
+.collapse-btn:hover {
+  background: #0059d6;
 }
 
 #printBtn {


### PR DESCRIPTION
## Summary
- Auto-expand "Motivo de la paralización" textarea with light blue background
- Add blue arrow button to collapse suggestion list
- Send `motivoResumido` to spreadsheet via Apps Script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check paralizacion.gs` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_6897e068e448832ebc45141da999b994