### PR TITLE
Actualizar UI y calendario de proyecto

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -30,8 +30,8 @@
 
     <div class="container form-container">
       <div class="calc-mascot">
-        <img src="Certy_celular.png" alt="Certy">
-        <div class="speech">Completa los datos</div>
+      <img src="Certy_trabajando.png" alt="Certy">
+      <div class="speech">Completa los datos</div>
       </div>
       <h1>Calculadora de Días y Fojas</h1>
       <p class="subtitle">Con la siguiente calculadora vamos a calcular la fecha de finalización de la obra y fojas a realizar.</p>

--- a/common.js
+++ b/common.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
       toggle.textContent = theme === 'dark' ? '🌙' : '🌞';
       toggle.setAttribute('aria-label', theme === 'dark' ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro');
     };
-    let currentTheme = localStorage.getItem('theme') || 'light';
+    let currentTheme = localStorage.getItem('theme') || 'dark';
     applyTheme(currentTheme);
     toggle.addEventListener('click', () => {
       currentTheme = currentTheme === 'light' ? 'dark' : 'light';

--- a/index.html
+++ b/index.html
@@ -23,25 +23,27 @@
 
   <section class="hero">
     <div class="hero-content">
-      <img src="Certy_celular.png" alt="Certy" class="certy-hero">
-      <h1 class="speech">¡Hola! Soy Certy, ¿Qué vamos a hacer hoy?<span class="cursor">_</span></h1>
+      <div class="robot-container">
+        <img src="Certy_celular.png" alt="Certy" class="certy-hero">
+        <h1 class="speech-bubble">¡Hola! Soy Certy, ¿Qué vamos a hacer hoy?<span class="cursor">_</span></h1>
+      </div>
     </div>
     <div class="card-grid">
       <a href="calculator.html" class="card-button" aria-label="Calculadora de Días y Fojas para Obras">
-        <i class="fa-solid fa-helmet-safety"></i>
-        <span>Calculadora de Días y Fojas para <strong>OBRAS</strong></span>
+        <img src="logo_obra.png" alt="Obras" class="card-icon">
+        <span class="card-text">Calculadora de Días y Fojas para <strong>OBRAS</strong></span>
       </a>
       <a href="project.html" class="card-button" aria-label="Calculadora de Días y Fojas para Proyectos">
-        <i class="fa-solid fa-file-lines"></i>
-        <span>Calculadora de Días y Fojas para <strong>PROYECTOS</strong></span>
+        <img src="logo_proyecto.png" alt="Proyectos" class="card-icon">
+        <span class="card-text">Calculadora de Días y Fojas para <strong>PROYECTOS</strong></span>
       </a>
       <a href="paralizacion.html" class="card-button accent" aria-label="Solicitar paralización (próximamente)">
-        <i class="fa-solid fa-triangle-exclamation"></i>
-        <span>Solicitar Paralización<br>(Próximamente)</span>
+        <img src="Certy_procesando.png" alt="Solicitar Paralización" class="card-icon">
+        <span class="card-text">Solicitar Paralización<br>(Próximamente)</span>
       </a>
       <div class="card-button disabled" aria-label="Próximamente más funciones">
-        <i class="fa-solid fa-bolt"></i>
-        <span>Próximamente Más Funciones</span>
+        <img src="logo.png" alt="Más funciones" class="card-icon">
+        <span class="card-text">Próximamente Más Funciones</span>
       </div>
     </div>
   </section>

--- a/paralizacion.html
+++ b/paralizacion.html
@@ -24,7 +24,7 @@
 
   <div class="container form-container">
     <div class="calc-mascot">
-      <img src="Certy_celular.png" alt="Certy">
+      <img src="Certy_trabajando.png" alt="Certy">
       <div class="speech">Completá los datos</div>
     </div>
     <h1>Solicitar Paralización</h1>

--- a/project.html
+++ b/project.html
@@ -30,7 +30,7 @@
 
   <div class="container form-container">
     <div class="calc-mascot">
-      <img src="Certy_celular.png" alt="Certy">
+      <img src="Certy_trabajando.png" alt="Certy">
       <div class="speech">Completa los datos</div>
     </div>
     <h1>Calculadora de Días y Fojas para PROYECTOS</h1>

--- a/project.js
+++ b/project.js
@@ -72,6 +72,57 @@ function generarTablaFojas(fojas) {
   return tablaHTML;
 }
 
+function generateCalendar(startDate, endDate, suspensions = [], pauses = []) {
+  const months = [];
+  let current = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+  const last = new Date(endDate.getFullYear(), endDate.getMonth(), 1);
+  while (current <= last) {
+    months.push(new Date(current));
+    current.setMonth(current.getMonth() + 1);
+  }
+
+  const isSuspension = date => {
+    return suspensions.some(([s, e]) => date >= s && date <= e) ||
+           pauses.some(([s, e]) => date >= s && date <= e);
+  };
+
+  const isMeasurement = date => {
+    return suspensions.some(([s, e]) => date.getTime() === addDays(e, 1).getTime()) ||
+           pauses.some(([s, e]) => date.getTime() === addDays(e, 1).getTime());
+  };
+
+  let html = '<div class="calendar">';
+  months.forEach(mDate => {
+    const year = mDate.getFullYear();
+    const month = mDate.getMonth();
+    const monthName = mDate.toLocaleString('es-AR', { month: 'long', year: 'numeric' });
+    html += `<div class="month"><h4>${monthName}</h4><table><thead><tr>`;
+    ['Dom','Lun','Mar','Mié','Jue','Vie','Sáb'].forEach(d => html += `<th>${d}</th>`);
+    html += '</tr></thead><tbody><tr>';
+    const firstDay = new Date(year, month, 1).getDay();
+    for (let i = 0; i < firstDay; i++) html += '<td></td>';
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    for (let day = 1; day <= daysInMonth; day++) {
+      const currentDay = new Date(year, month, day);
+      let className = '';
+      if (currentDay >= startDate && currentDay <= endDate) {
+        if (isSuspension(currentDay)) className = 'suspension-day';
+        else if (isMeasurement(currentDay)) className = '';
+        else className = 'work-day';
+      }
+      html += `<td class="${className}">${day}</td>`;
+      if ((firstDay + day) % 7 === 0 && day !== daysInMonth) html += '</tr><tr>';
+    }
+    const trailing = (firstDay + daysInMonth) % 7;
+    if (trailing !== 0) {
+      for (let i = 0; i < 7 - trailing; i++) html += '<td></td>';
+    }
+    html += '</tr></tbody></table></div>';
+  });
+  html += '</div>';
+  return html;
+}
+
 function calculate() {
   const rawStart = document.getElementById("startDate").value;
   const [year, month, day] = rawStart.split("-").map(Number);
@@ -167,7 +218,10 @@ function calculate() {
   resultHTML += `<p><strong>Foja Nº Final:</strong> ${fojas.length} FINAL</p>`;
   resultHTML += generarTablaFojas(fojas);
 
-  document.getElementById("result").innerHTML = resultHTML;
+  const resultEl = document.getElementById("result");
+  resultEl.innerHTML = resultHTML;
+  const calendarHTML = generateCalendar(startDate, currentDate, suspensions, pauses);
+  resultEl.insertAdjacentHTML('beforeend', calendarHTML);
   document.getElementById('printBtn').style.display = 'block';
 }
 
@@ -205,6 +259,7 @@ async function openPdfReport() {
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
   const originalWordSpacing = resultEl.style.wordSpacing;
+  const originalLetterSpacing = resultEl.style.letterSpacing;
   const textNodes = [];
   const walker = document.createTreeWalker(resultEl, NodeFilter.SHOW_TEXT, null, false);
   while (walker.nextNode()) {
@@ -215,6 +270,7 @@ async function openPdfReport() {
     }
   }
   resultEl.style.wordSpacing = '4px';
+  resultEl.style.letterSpacing = '1px';
 
   const originalStyles = new Map();
   const elements = resultEl.getElementsByTagName('*');
@@ -240,7 +296,8 @@ async function openPdfReport() {
       const pageH = doc.internal.pageSize.getHeight();
       const pageW = doc.internal.pageSize.getWidth();
       doc.setFontSize(12);
-      doc.setFont('helvetica', 'italic');
+      doc.setFont('helvetica', 'normal');
+      doc.setCharSpace(1);
       doc.setTextColor(0, 0, 0);
 
       const finalize = () => {
@@ -250,6 +307,7 @@ async function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
+        resultEl.style.letterSpacing = originalLetterSpacing;
 
         const blob = doc.output('blob');
         const url = URL.createObjectURL(blob);
@@ -261,7 +319,7 @@ async function openPdfReport() {
       };
 
       const img = new Image();
-      img.src = 'Robot.png';
+      img.src = 'Certy_saludando.png';
       img.onload = function() {
         const imgSize = 16;
         const xImg = pageW - 40 - imgSize;

--- a/script.js
+++ b/script.js
@@ -278,6 +278,7 @@ async function openPdfReport() {
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ unit: 'pt', format: 'a4' });
   const originalWordSpacing = resultEl.style.wordSpacing;
+  const originalLetterSpacing = resultEl.style.letterSpacing;
   const textNodes = [];
   const walker = document.createTreeWalker(resultEl, NodeFilter.SHOW_TEXT, null, false);
   while (walker.nextNode()) {
@@ -288,6 +289,7 @@ async function openPdfReport() {
     }
   }
   resultEl.style.wordSpacing = '4px';
+  resultEl.style.letterSpacing = '1px';
 
   // Save original styles using a Map to restore them later
   const originalStyles = new Map();
@@ -314,7 +316,8 @@ async function openPdfReport() {
       const pageH = doc.internal.pageSize.getHeight();
       const pageW = doc.internal.pageSize.getWidth();
       doc.setFontSize(12);
-      doc.setFont('helvetica', 'italic');
+      doc.setFont('helvetica', 'normal');
+      doc.setCharSpace(1);
       doc.setTextColor(0, 0, 0); // Black text
 
       const finalize = () => {
@@ -324,6 +327,7 @@ async function openPdfReport() {
         }
         textNodes.forEach(({ node, text }) => (node.nodeValue = text));
         resultEl.style.wordSpacing = originalWordSpacing;
+        resultEl.style.letterSpacing = originalLetterSpacing;
 
         const blob = doc.output('blob');
         const url = URL.createObjectURL(blob);
@@ -335,7 +339,7 @@ async function openPdfReport() {
       };
 
       const img = new Image();
-      img.src = 'Robot.png';
+      img.src = 'Certy_saludando.png';
       img.onload = function() {
         const imgSize = 16;
         const xImg = pageW - 40 - imgSize;

--- a/styles.css
+++ b/styles.css
@@ -55,7 +55,7 @@ body.dark .site-header {
 }
 
 .logo-group img {
-  height: 50px;
+  height: 80px;
 }
 
 .logo-group .dept {
@@ -87,6 +87,10 @@ body.dark .site-header {
   font-size: 1.2rem;
   cursor: pointer;
   transition: transform 0.3s, background 0.3s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 
 #themeToggle:hover {
@@ -126,25 +130,55 @@ body.dark #themeToggle {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
   flex-wrap: wrap;
   margin-bottom: 2rem;
 }
 
-.speech {
+
+.robot-container {
+  position: relative;
+  display: inline-block;
+}
+
+.speech-bubble {
   background: var(--card-bg);
-  padding: 1rem 1.5rem;
+  padding: 0.5rem 1rem;
   border-radius: var(--card-radius);
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  font-size: 1.2rem;
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translate(-50%, -100%);
   white-space: nowrap;
-  font-size: clamp(1.5rem, 4vw, 3rem);
+}
+
+.speech-bubble::after {
+  content: '';
+  position: absolute;
+  bottom: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 20px;
+  height: 20px;
+  background: var(--card-bg);
+  clip-path: polygon(0 0, 100% 0, 50% 100%);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.speech {
+  background: var(--card-bg);
+  padding: 0.5rem 1rem;
+  border-radius: var(--card-radius);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  font-size: 1rem;
   position: relative;
 }
 
 .speech::after {
   content: '';
   position: absolute;
-  left: 20px;
+  left: 10px;
   bottom: -10px;
   width: 20px;
   height: 20px;
@@ -159,28 +193,35 @@ body.dark #themeToggle {
 
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 1.5rem;
 }
 
 .card-button {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   background: var(--card-bg);
   border-radius: var(--card-radius);
-  padding: 2rem 1rem;
+  padding: 1rem;
   text-decoration: none;
   color: var(--color-text);
   font-weight: 600;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   transition: transform 0.2s, box-shadow 0.2s;
+  height: 120px;
 }
 
-.card-button i {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
+.card-icon {
+  height: 100%;
+  max-height: 100px;
+  width: auto;
+}
+
+.card-text {
+  flex: 1;
+  text-align: right;
 }
 
 .card-button:hover {
@@ -267,7 +308,7 @@ h1 {
 
 .subtitle {
   text-align: center;
-  color: #666;
+  color: #fff;
   margin-bottom: 1.5rem;
 }
 
@@ -476,8 +517,9 @@ body.dark-mode #themeToggle {
 }
 
 .warning {
-  background-color: #ffd8a8;
-  border: 1px solid #ffa94d;
+  background-color: #cc5500;
+  border: 1px solid #cc5500;
+  color: #fff;
   padding: 0.5rem;
   border-radius: 4px;
   font-weight: bold;
@@ -493,6 +535,48 @@ body.dark-mode #themeToggle {
   font-weight: bold;
 }
 
+.calendar {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.month {
+  background: #fff;
+  color: #000;
+  padding: 0.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.month h4 {
+  margin: 0.5rem 0;
+  text-align: center;
+}
+
+.month table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.month th,
+.month td {
+  width: 14.2%;
+  text-align: center;
+  padding: 4px;
+}
+
+.work-day {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.suspension-day {
+  background: #002b6b;
+  color: #fff;
+}
 @media (max-width: 480px) {
   body {
     padding-top: 90px;


### PR DESCRIPTION
## Resumen
- Reducir globo de saludo y reubicarlo sobre la cabeza del robot en el menú principal
- Reorganizar botones en cuadrícula 2x2 con íconos a la izquierda e incorporar icono de procesamiento
- Activar modo oscuro por defecto y ajustar botón de tema y tamaños de logo
- Mejorar formularios: nuevo robot trabajando, textos aclaratorios blancos y carteles de advertencia en naranja oscuro
- Generar informes PDF con tipografía normal, mayor espaciado y robot saludando
- Añadir calendario de ejecución en proyectos con días trabajados en naranja y suspensiones en azul

## Pruebas
- `npm test` *(falla: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3e6e230d8832ea4c3aad7402ce151