### PR TITLE
Adjust layout and report styling

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -20,7 +20,6 @@
     <button class="back-btn" onclick="window.location.href='index.html'" aria-label="Volver al menú principal"><i class="fa-solid fa-arrow-left"></i></button>
     <div class="logo-group">
       <img src="NeuquénCapital_logo.png" alt="Logo Neuquén Capital">
-      <span class="dept">Dirección Municipal de Certificaciones</span>
     </div>
     <div class="header-actions">
       <img src="Certy_logo.png" alt="Avatar de Certy" class="certy-avatar">
@@ -28,11 +27,12 @@
     </div>
   </header>
 
-    <div class="container form-container">
+    <div class="form-wrapper">
       <div class="calc-mascot">
-      <img src="Certy_trabajando.png" alt="Certy">
-      <div class="speech">Completa los datos</div>
+        <img src="Certy_trabajando.png" alt="Certy">
+        <div class="speech">Completa los datos</div>
       </div>
+      <div class="container form-container">
       <h1>Calculadora de Días y Fojas</h1>
       <p class="subtitle">Con la siguiente calculadora vamos a calcular la fecha de finalización de la obra y fojas a realizar.</p>
 
@@ -70,7 +70,8 @@
 
     <div id="result"></div>
     <button id="printBtn" onclick="openPdfReport()" style="display:none;">Imprimir informe en PDF</button>
-  </div>
+      </div>
+    </div>
 
     <script src="common.js"></script>
     <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
   <header class="site-header">
     <div class="logo-group">
       <img src="NeuquénCapital_logo.png" alt="Logo Neuquén Capital">
-      <span class="dept">Dirección Municipal de Certificaciones</span>
     </div>
     <div class="header-actions">
       <img src="Certy_logo.png" alt="Avatar de Certy" class="certy-avatar">

--- a/paralizacion.html
+++ b/paralizacion.html
@@ -14,7 +14,6 @@
     <button class="back-btn" onclick="window.location.href='index.html'" aria-label="Volver al menú principal"><i class="fa-solid fa-arrow-left"></i></button>
     <div class="logo-group">
       <img src="NeuquénCapital_logo.png" alt="Logo Neuquén Capital">
-      <span class="dept">Dirección Municipal de Certificaciones</span>
     </div>
     <div class="header-actions">
       <img src="Certy_logo.png" alt="Avatar de Certy" class="certy-avatar">
@@ -22,11 +21,12 @@
     </div>
   </header>
 
-  <div class="container form-container">
+  <div class="form-wrapper">
     <div class="calc-mascot">
       <img src="Certy_trabajando.png" alt="Certy">
       <div class="speech">Completá los datos</div>
     </div>
+    <div class="container form-container">
     <h1>Solicitar Paralización</h1>
       <label>N° de expediente:</label>
       <div class="expediente-input">
@@ -94,6 +94,7 @@
         <button id="solicitarBtn" type="submit">SOLICITAR</button>
       </div>
     </form>
+    </div>
   </div>
 
   <script src="common.js"></script>

--- a/project.html
+++ b/project.html
@@ -20,7 +20,6 @@
     <button class="back-btn" onclick="window.location.href='index.html'" aria-label="Volver al menú principal"><i class="fa-solid fa-arrow-left"></i></button>
     <div class="logo-group">
       <img src="NeuquénCapital_logo.png" alt="Logo Neuquén Capital">
-      <span class="dept">Dirección Municipal de Certificaciones</span>
     </div>
     <div class="header-actions">
       <img src="Certy_logo.png" alt="Avatar de Certy" class="certy-avatar">
@@ -28,11 +27,12 @@
     </div>
   </header>
 
-  <div class="container form-container">
+  <div class="form-wrapper">
     <div class="calc-mascot">
       <img src="Certy_trabajando.png" alt="Certy">
       <div class="speech">Completa los datos</div>
     </div>
+    <div class="container form-container">
     <h1>Calculadora de Días y Fojas para PROYECTOS</h1>
     <p class="subtitle">Con la siguiente calculadora vamos a calcular la fecha de finalización del proyecto y fojas a realizar.</p>
 
@@ -69,6 +69,7 @@
 
     <div id="result"></div>
     <button id="printBtn" onclick="openPdfReport()" style="display:none;">Imprimir informe en PDF</button>
+    </div>
   </div>
 
     <script src="common.js"></script>

--- a/project.js
+++ b/project.js
@@ -278,7 +278,7 @@ async function openPdfReport() {
   doc.html(resultEl, {
     margin: [40, 40, 40, 40],
     html2canvas: {
-      scale: 3,
+      scale: 0.8,
       logging: true,
       useCORS: true
     },
@@ -385,7 +385,7 @@ document.getElementById("hasSuspensions").addEventListener("change", function ()
       for (let i = 1; i <= count; i++) {
         container.innerHTML += `
           <div class="suspensionGroup">
-            <p class="suspensionSuggestion suggestion-box suggestion"></p>
+            <p class="suspensionSuggestion suggestion"></p>
             <label>Suspensión ${i}:
               <input type="text" class="suspensionRange" placeholder="Seleccionar rango"/>
             </label>

--- a/solicitud_paralizacion.html
+++ b/solicitud_paralizacion.html
@@ -14,7 +14,6 @@
     <button class="back-btn" onclick="window.location.href='index.html'" aria-label="Volver al menú principal"><i class="fa-solid fa-arrow-left"></i></button>
     <div class="logo-group">
       <img src="NeuquénCapital_logo.png" alt="Logo Neuquén Capital">
-      <span class="dept">Dirección Municipal de Certificaciones</span>
     </div>
     <div class="header-actions">
       <img src="Certy_logo.png" alt="Avatar de Certy" class="certy-avatar">
@@ -22,11 +21,12 @@
     </div>
   </header>
 
-  <div class="container form-container">
+  <div class="form-wrapper">
     <div class="calc-mascot">
       <img src="Certy_celular.png" alt="Certy">
       <div class="speech">Completá la solicitud</div>
     </div>
+    <div class="container form-container">
     <h1>Solicitud de Paralización</h1>
     <form id="paralizacionForm">
       <label for="fechaSolicitud">Fecha de solicitud</label>
@@ -57,6 +57,7 @@
 
       <button type="submit">Solicitar</button>
     </form>
+    </div>
   </div>
 
   <script src="common.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -148,22 +148,22 @@ body.dark #themeToggle {
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   font-size: 1.2rem;
   position: absolute;
-  top: -10px;
-  left: 50%;
-  transform: translate(-50%, -100%);
+  top: 50%;
+  left: 100%;
+  transform: translate(10px, -50%);
   white-space: nowrap;
 }
 
 .speech-bubble::after {
   content: '';
   position: absolute;
-  bottom: -10px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 50%;
+  left: -10px;
+  transform: translateY(-50%);
   width: 20px;
   height: 20px;
   background: var(--card-bg);
-  clip-path: polygon(0 0, 100% 0, 50% 100%);
+  clip-path: polygon(100% 0, 100% 100%, 0 50%);
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
@@ -247,12 +247,23 @@ body.dark #themeToggle {
   justify-content: center;
 }
 
+.form-wrapper {
+  position: relative;
+  max-width: 600px;
+  margin: 2rem auto;
+}
+
+.form-wrapper .container {
+  margin: 0;
+}
+
 .calc-mascot {
+  position: absolute;
+  top: -40px;
+  left: -60px;
   display: flex;
   align-items: flex-start;
   gap: 1rem;
-  margin-bottom: 1rem;
-  margin-left: -60px;
 }
 
 .calc-mascot img {
@@ -582,7 +593,7 @@ body.dark-mode #themeToggle {
 }
 
 .suspension-day {
-  background: #002b6b;
+  background: var(--color-primary);
   color: #fff;
 }
 
@@ -602,7 +613,7 @@ body.dark-mode #themeToggle {
 }
 
 .pdf-export .suspension-day {
-  background: #002b6b !important;
+  background: var(--color-primary) !important;
   color: #fff !important;
 }
 


### PR DESCRIPTION
## Summary
- Reposition main menu speech bubble beside the mascot and drop certification tagline from headers.
- Highlight project suspension days in blue and keep suspension inputs styled like other fields.
- Scale project report PDF to fit on one page and move mascot dialog outside form boxes across pages.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3f7bca508832e9550e9cd5464659a