### PR TITLE
Reduce logo and button width; adjust speech bubble for dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <div class="hero-content">
       <div class="robot-container">
         <img src="Certy_celular.png" alt="Certy" class="certy-hero">
-        <h1 class="speech-bubble">¡Hola! Soy Certy, ¿Qué vamos a hacer hoy?<span class="cursor">_</span></h1>
+        <h1 class="speech-bubble">¡Hola! Soy Certy,<br>¿Qué vamos a hacer hoy?<span class="cursor">_</span></h1>
       </div>
     </div>
     <div class="card-grid">

--- a/styles.css
+++ b/styles.css
@@ -55,7 +55,7 @@ body.dark .site-header {
 }
 
 .logo-group img {
-  height: 120px;
+  height: 60px;
 }
 
 .logo-group .dept {
@@ -158,10 +158,10 @@ body.dark #themeToggle {
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   font-size: 1.2rem;
   position: absolute;
-  top: 50%;
+  top: 0;
   left: 100%;
-  transform: translate(10px, -50%);
-  white-space: nowrap;
+  transform: translate(10px, 0);
+  white-space: normal;
 }
 
 .speech-bubble::after {
@@ -175,6 +175,10 @@ body.dark #themeToggle {
   background: var(--card-bg);
   clip-path: polygon(100% 0, 100% 100%, 0 50%);
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+body.dark .speech-bubble {
+  color: #fff;
 }
 
 .speech {
@@ -222,6 +226,8 @@ body.dark #themeToggle {
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   transition: transform 0.2s, box-shadow 0.2s;
   height: 90px;
+  width: 50%;
+  justify-self: center;
 }
 
 .card-icon {


### PR DESCRIPTION
## Summary
- Shrink Neuquén Capital logo
- Halve card button width for compact layout
- Tweak speech bubble: white text and two-line message in dark mode

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a688e56e68832e820d319e592c3e52