### PR TITLE
Refine main menu layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,10 @@
     <div class="hero-content">
       <div class="robot-container">
         <img src="Certy_celular.png" alt="Certy" class="certy-hero">
-        <h1 class="speech-bubble">¡Hola! Soy Certy,<br>¿Qué vamos a hacer hoy?<span class="cursor">_</span></h1>
+        <h1 class="speech-bubble">
+          <span>¡Hola! Soy Certy,</span><br>
+          <span>¿Qué vamos a hacer hoy?<span class="cursor">_</span></span>
+        </h1>
       </div>
     </div>
     <div class="card-grid">

--- a/styles.css
+++ b/styles.css
@@ -209,7 +209,7 @@ body.dark .speech-bubble {
 .card-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
+  gap: 0.5rem;
 }
 
 .card-button {
@@ -226,8 +226,7 @@ body.dark .speech-bubble {
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   transition: transform 0.2s, box-shadow 0.2s;
   height: 90px;
-  width: 50%;
-  justify-self: center;
+  width: 100%;
 }
 
 .card-icon {


### PR DESCRIPTION
## Summary
- Adjust robot greeting to span two lines in a single speech bubble
- Reduce spacing in main menu card grid and make buttons full width

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a68c804f84832ea85cb9a611e63500