### PR TITLE
Revise home layout for centered responsive cards and robot dialogue

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,18 +33,19 @@
     </div>
     <div class="card-grid">
       <a href="calculator.html" class="card-button" aria-label="Calculadora de Días y Fojas para Obras">
-        <img src="logo_obra.png" alt="Obras" class="card-icon">
+        <div class="card-icon"><img src="logo_obra.png" alt="Obras"></div>
         <span class="card-text">Calculadora de Días y Fojas para <strong>OBRAS</strong></span>
       </a>
       <a href="project.html" class="card-button" aria-label="Calculadora de Días y Fojas para Proyectos">
-        <img src="logo_proyecto.png" alt="Proyectos" class="card-icon">
+        <div class="card-icon"><img src="logo_proyecto.png" alt="Proyectos"></div>
         <span class="card-text">Calculadora de Días y Fojas para <strong>PROYECTOS</strong></span>
       </a>
-      <a href="paralizacion.html" class="card-button accent" aria-label="Solicitar paralización (próximamente)">
-        <img src="Certy_procesando.png" alt="Solicitar Paralización" class="card-icon">
+      <div class="card-button accent disabled" role="button" aria-label="Solicitar paralización (próximamente)" aria-disabled="true" tabindex="-1">
+        <div class="card-icon"><img src="Certy_procesando.png" alt="Solicitar Paralización"></div>
         <span class="card-text">Solicitar Paralización<br>(Próximamente)</span>
-      </a>
-      <div class="card-button disabled no-icon center-button" aria-label="Próximamente más funciones">
+      </div>
+      <div class="card-button disabled" role="button" aria-label="Próximamente más funciones" aria-disabled="true" tabindex="-1">
+        <div class="card-icon"></div>
         <span class="card-text">Próximamente Más Funciones</span>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -131,9 +131,14 @@ body.dark #themeToggle {
 }
 
 .hero {
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 4rem 1rem 2rem;
+  padding: 2rem 1rem;
+  min-height: calc(100vh - 90px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2rem;
   text-align: center;
 }
 
@@ -153,15 +158,23 @@ body.dark #themeToggle {
 
 .speech-bubble {
   background: var(--card-bg);
-  padding: 0.5rem 1rem;
+  padding: 0.75rem 1rem;
   border-radius: var(--card-radius);
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-  font-size: 1.2rem;
+  font-size: clamp(1rem, 2vw + 0.5rem, 1.3rem);
   position: absolute;
   top: 0;
   left: 100%;
   transform: translate(10px, 0);
-  white-space: normal;
+  display: inline-block;
+  max-width: 90vw;
+  width: max-content;
+  line-height: 1.3;
+}
+
+.speech-bubble span {
+  display: block;
+  white-space: nowrap;
 }
 
 .speech-bubble::after {
@@ -208,43 +221,61 @@ body.dark .speech-bubble {
 
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.5rem;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .card-button {
   display: flex;
-  flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+  gap: 1rem;
   background: var(--card-bg);
   border-radius: var(--card-radius);
-  padding: 1rem;
+  padding: 1rem 1.5rem;
   text-decoration: none;
   color: var(--color-text);
   font-weight: 600;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   transition: transform 0.2s, box-shadow 0.2s;
-  height: 90px;
+  height: 130px;
   width: 100%;
 }
 
 .card-icon {
-  height: 100%;
-  max-height: 100px;
-  width: auto;
-  -webkit-mask-image: linear-gradient(to right, black 70%, transparent);
-  mask-image: linear-gradient(to right, black 70%, transparent);
+  flex: 0 0 80px;
+  height: 80px;
+  width: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.card-icon img {
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .card-text {
   flex: 1;
-  text-align: right;
+  text-align: left;
 }
 
-.card-button:hover {
-  transform: scale(1.03);
+.card-button:hover:not(.disabled) {
+  transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(0,0,0,0.15);
+}
+
+.card-button:active:not(.disabled) {
+  transform: scale(0.98);
 }
 
 .card-button.accent {
@@ -258,15 +289,6 @@ body.dark .speech-bubble {
   pointer-events: none;
 }
 
-.card-button.no-icon {
-  justify-content: center;
-}
-
-.card-button.center-button {
-  grid-column: 1 / -1;
-  justify-self: center;
-  width: 60%;
-}
 
 .form-wrapper {
   position: relative;


### PR DESCRIPTION
## Summary
- Center home section with max-width container and vertically aligned content
- Redesign card grid with consistent sizing, accessibility and responsive breakpoints
- Force robot speech bubble to display exactly two lines across viewports

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a69170cdf8832e82444bbd567c3d1f