### PR TITLE
Fix menu spacing and reactivate Solicitar Paralización link

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,10 +40,10 @@
         <div class="card-icon"><img src="logo_proyecto.png" alt="Proyectos"></div>
         <span class="card-text">Calculadora de Días y Fojas para <strong>PROYECTOS</strong></span>
       </a>
-      <div class="card-button accent disabled" role="button" aria-label="Solicitar paralización (próximamente)" aria-disabled="true" tabindex="-1">
+      <a href="paralizacion.html" class="card-button accent" aria-label="Solicitar paralización">
         <div class="card-icon"><img src="Certy_procesando.png" alt="Solicitar Paralización"></div>
-        <span class="card-text">Solicitar Paralización<br>(Próximamente)</span>
-      </div>
+        <span class="card-text">Solicitar Paralización</span>
+      </a>
       <div class="card-button disabled" role="button" aria-label="Próximamente más funciones" aria-disabled="true" tabindex="-1">
         <div class="card-icon"></div>
         <span class="card-text">Próximamente Más Funciones</span>

--- a/styles.css
+++ b/styles.css
@@ -244,7 +244,7 @@ body.dark .speech-bubble {
   font-weight: 600;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   transition: transform 0.2s, box-shadow 0.2s;
-  height: 130px;
+  min-height: 130px;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- Ensure main menu cards expand vertically to avoid overlap
- Enable Solicitar Paralización card and link it to the paralización page

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8a1bae594832e9a28fb8388eaaf2a