### PR TITLE
Refactor menu structure and card button styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,24 +31,34 @@
         </h1>
       </div>
     </div>
-    <div class="card-grid">
-      <a href="calculator.html" class="card-button" aria-label="Calculadora de Días y Fojas para Obras">
-        <div class="card-icon"><img src="logo_obra.png" alt="Obras"></div>
-        <span class="card-text">Calculadora de Días y Fojas para <strong>OBRAS</strong></span>
-      </a>
-      <a href="project.html" class="card-button" aria-label="Calculadora de Días y Fojas para Proyectos">
-        <div class="card-icon"><img src="logo_proyecto.png" alt="Proyectos"></div>
-        <span class="card-text">Calculadora de Días y Fojas para <strong>PROYECTOS</strong></span>
-      </a>
-      <a href="paralizacion.html" class="card-button accent" aria-label="Solicitar paralización">
-        <div class="card-icon"><img src="Certy_procesando.png" alt="Solicitar Paralización"></div>
-        <span class="card-text">Solicitar Paralización</span>
-      </a>
-      <div class="card-button disabled" role="button" aria-label="Próximamente más funciones" aria-disabled="true" tabindex="-1">
-        <div class="card-icon"></div>
-        <span class="card-text">Próximamente Más Funciones</span>
-      </div>
-    </div>
+    <nav>
+      <ul class="card-grid">
+        <li>
+          <a href="calculator.html" class="card-button" aria-label="Calculadora de Días y Fojas para Obras">
+            <div class="card-icon"><img src="logo_obra.png" alt="Obras"></div>
+            <span class="card-text">Calculadora de Días y Fojas para <strong>OBRAS</strong></span>
+          </a>
+        </li>
+        <li>
+          <a href="project.html" class="card-button" aria-label="Calculadora de Días y Fojas para Proyectos">
+            <div class="card-icon"><img src="logo_proyecto.png" alt="Proyectos"></div>
+            <span class="card-text">Calculadora de Días y Fojas para <strong>PROYECTOS</strong></span>
+          </a>
+        </li>
+        <li>
+          <a href="paralizacion.html" class="card-button accent" aria-label="Solicitar paralización">
+            <div class="card-icon"><img src="Certy_procesando.png" alt="Solicitar Paralización"></div>
+            <span class="card-text">Solicitar Paralización</span>
+          </a>
+        </li>
+        <li>
+          <button class="card-button" aria-label="Próximamente más funciones" disabled>
+            <div class="card-icon"></div>
+            <span class="card-text">Próximamente Más Funciones</span>
+          </button>
+        </li>
+      </ul>
+    </nav>
   </section>
 
   <button id="downloadAppBtn" onclick="installApp()" aria-label="Descargar aplicación de Certy">

--- a/styles.css
+++ b/styles.css
@@ -221,15 +221,13 @@ body.dark .speech-bubble {
 
 .card-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1.5rem;
-  width: 100%;
-}
-
-@media (min-width: 768px) {
-  .card-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .card-button {
@@ -269,12 +267,14 @@ body.dark .speech-bubble {
   text-align: left;
 }
 
-.card-button:hover:not(.disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0,0,0,0.15);
+
+.card-button:not([disabled]):hover,
+.card-button:not([disabled]):focus-visible {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.2);
 }
 
-.card-button:active:not(.disabled) {
+.card-button:not([disabled]):active {
   transform: scale(0.98);
 }
 
@@ -283,7 +283,7 @@ body.dark .speech-bubble {
   color: #fff;
 }
 
-.card-button.disabled {
+.card-button[disabled] {
   opacity: 0.6;
   cursor: not-allowed;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- Wrap home menu items within a `<nav>` and `<ul class="card-grid">`, placing each card in an `<li>` and replacing the placeholder card with a disabled `<button>`
- Update `.card-grid` for responsive CSS grid layout and reset default list styles
- Switch disabled styling to `[disabled]` attribute and add hover/focus effects for active card buttons

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9018859a4832ebd7466fefb1c5195