### PR TITLE
Modernize main menu layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <li>
           <a href="paralizacion.html" class="card-button accent" aria-label="Solicitar paralización">
             <div class="card-icon"><img src="Certy_procesando.png" alt="Solicitar Paralización"></div>
-            <span class="card-text">Solicitar Paralización</span>
+            <span class="card-text">Solicitar Paralización (PRÓXIMAMENTE)</span>
           </a>
         </li>
         <li>

--- a/styles.css
+++ b/styles.css
@@ -24,7 +24,7 @@ body {
 body.dark {
   --color-bg: #0a0f1f;
   --color-text: #f5f5f5;
-  --card-bg: #1b2130;
+  --card-bg: #2a3145;
   background-image: radial-gradient(rgba(255,255,255,0.1) 1px, transparent 1px),
     linear-gradient(135deg, var(--color-bg), #000);
 }
@@ -219,37 +219,46 @@ body.dark .speech-bubble {
   max-width: 200px;
 }
 
+
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
   list-style: none;
-  margin: 0;
-  padding: 0;
-  max-width: 1200px;
   margin: 0 auto;
+  padding: 0;
+  max-width: 800px;
+}
+
+@media (max-width: 600px) {
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .card-button {
   display: flex;
+  flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 1rem;
   background: var(--card-bg);
   border-radius: var(--card-radius);
-  padding: 1rem 1.5rem;
+  padding: 2rem;
   text-decoration: none;
   color: var(--color-text);
   font-weight: 600;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-  transition: transform 0.2s, box-shadow 0.2s;
-  min-height: 130px;
+  transition: transform 0.2s, box-shadow 0.2s, filter 0.2s;
+  min-height: 180px;
   width: 100%;
+  text-align: center;
 }
 
 .card-icon {
-  flex: 0 0 80px;
-  height: 80px;
-  width: 80px;
+  flex: 0 0 100px;
+  height: 100px;
+  width: 100px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -264,14 +273,15 @@ body.dark .speech-bubble {
 
 .card-text {
   flex: 1;
-  text-align: left;
+  text-align: center;
 }
 
 
 .card-button:not([disabled]):hover,
 .card-button:not([disabled]):focus-visible {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(0,0,0,0.3);
+  filter: brightness(1.05);
 }
 
 .card-button:not([disabled]):active {
@@ -279,7 +289,7 @@ body.dark .speech-bubble {
 }
 
 .card-button.accent {
-  background: var(--color-accent);
+  background: var(--color-secondary);
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- Refresh main menu with grid layout and centered cards
- Enlarge icons and add subtle hover effect
- Update paralización button text to indicate upcoming feature

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9036284dc832ebeb8000e7449dd08