### PR TITLE
feat: redesign home layout

### DIFF
--- a/common.js
+++ b/common.js
@@ -16,6 +16,18 @@ document.addEventListener('DOMContentLoaded', () => {
       applyTheme(currentTheme);
     });
   }
+
+  const downloadBtn = document.getElementById('downloadAppBtn');
+  if (downloadBtn) {
+    window.addEventListener('load', () => {
+      setTimeout(() => {
+        downloadBtn.classList.add('hide');
+        setTimeout(() => {
+          downloadBtn.style.display = 'none';
+        }, 500);
+      }, 3000);
+    });
+  }
 });
 
 function installApp() {

--- a/index.html
+++ b/index.html
@@ -9,72 +9,72 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-  <header class="site-header">
-    <div class="logo-group">
-      <img src="NeuquénCapital_logo.png" alt="Logo Neuquén Capital">
+<body class="home">
+  <header class="hero-header">
+    <div class="hero-info">
+      <img src="Certy_logo.png" alt="Certy" class="hero-logo" loading="lazy">
+      <p class="hero-claim">Tu asistente digital de certificaciones</p>
+      <a href="#servicios" class="btn-primary" aria-label="Ver opciones de Certy">Comenzar</a>
     </div>
-    <h2 class="dept-title">Dirección Municipal de Certificaciones</h2>
-    <div class="header-actions">
-      <img src="Certy_logo.png" alt="Avatar de Certy" class="certy-avatar">
-      <button id="themeToggle" aria-label="Cambiar a modo oscuro">🌞</button>
-    </div>
+    <img src="Certy_celular.png" alt="Certy con celular" class="hero-img" loading="lazy">
+    <button id="themeToggle" aria-label="Cambiar a modo oscuro" class="theme-toggle">🌞</button>
   </header>
 
-  <section class="hero">
-    <div class="hero-content">
-      <div class="robot-container">
-        <img src="Certy_celular.png" alt="Certy" class="certy-hero">
-        <h1 class="speech-bubble">
-          <span>¡Hola! Soy Certy,</span><br>
-          <span>¿Qué vamos a hacer hoy?<span class="cursor">_</span></span>
-        </h1>
-      </div>
-    </div>
-    <nav>
+  <main>
+    <nav id="servicios" aria-label="Opciones de Certy">
       <ul class="card-grid">
         <li>
           <a href="calculator.html" class="card-button" aria-label="Calculadora de Días y Fojas para Obras">
-            <div class="card-icon"><img src="logo_obra.png" alt="Obras"></div>
-            <span class="card-text">Calculadora de Días y Fojas para <strong>OBRAS</strong></span>
+            <img src="logo_obra.png" alt="Obras" class="card-img" loading="lazy">
+            <div class="card-content">
+              <h3 class="card-title">Calculadora de Días y Fojas</h3>
+              <p class="card-subtitle">para <strong>OBRAS</strong></p>
+            </div>
           </a>
         </li>
         <li>
           <a href="project.html" class="card-button" aria-label="Calculadora de Días y Fojas para Proyectos">
-            <div class="card-icon"><img src="logo_proyecto.png" alt="Proyectos"></div>
-            <span class="card-text">Calculadora de Días y Fojas para <strong>PROYECTOS</strong></span>
+            <img src="logo_proyecto.png" alt="Proyectos" class="card-img" loading="lazy">
+            <div class="card-content">
+              <h3 class="card-title">Calculadora de Días y Fojas</h3>
+              <p class="card-subtitle">para <strong>PROYECTOS</strong></p>
+            </div>
           </a>
         </li>
         <li>
           <a href="paralizacion.html" class="card-button accent" aria-label="Solicitar paralización">
-            <div class="card-icon"><img src="Certy_procesando.png" alt="Solicitar Paralización"></div>
-            <span class="card-text">Solicitar Paralización (PRÓXIMAMENTE)</span>
+            <img src="Certy_procesando.png" alt="Solicitar Paralización" class="card-img" loading="lazy">
+            <div class="card-content">
+              <h3 class="card-title">Solicitar Paralización</h3>
+              <p class="card-subtitle">(PRÓXIMAMENTE)</p>
+            </div>
           </a>
         </li>
         <li>
           <button class="card-button" aria-label="Próximamente más funciones" disabled>
-            <div class="card-icon"></div>
-            <span class="card-text">Próximamente Más Funciones</span>
+            <div class="card-img placeholder"></div>
+            <div class="card-content">
+              <h3 class="card-title">Próximamente</h3>
+              <p class="card-subtitle">Más Funciones</p>
+            </div>
           </button>
         </li>
       </ul>
     </nav>
-  </section>
+  </main>
 
   <button id="downloadAppBtn" onclick="installApp()" aria-label="Descargar aplicación de Certy">
     DESCARGAR CERTY EN TU CELULAR!<br><em>Sólo válido para Android</em>
   </button>
-  <script>
-    window.addEventListener('load', function() {
-      var btn = document.getElementById('downloadAppBtn');
-      setTimeout(function() {
-        btn.classList.add('hide');
-        setTimeout(function() { btn.style.display = 'none'; }, 500);
-      }, 3000);
-    });
-  </script>
+
+  <footer class="site-footer">
+    <p>&copy; 2024 Dirección Municipal de Certificaciones</p>
+    <a href="mailto:contacto@neuquencapital.gov.ar" aria-label="Contacto por correo">contacto@neuquencapital.gov.ar</a>
+  </footer>
+
   <script src="common.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.4.9/mammoth.browser.min.js"></script>
 </body>
 </html>
+

--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,10 @@ body {
   transition: background 0.3s, color 0.3s;
 }
 
+.home {
+  padding-top: 0;
+}
+
 body.dark {
   --color-bg: #0a0f1f;
   --color-text: #f5f5f5;
@@ -194,6 +198,79 @@ body.dark .speech-bubble {
   color: #fff;
 }
 
+.hero-header {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 32px 16px;
+  text-align: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.hero-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.hero-logo {
+  height: 96px;
+  width: auto;
+}
+
+.hero-claim {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.hero-img {
+  max-width: 320px;
+  width: 100%;
+  height: auto;
+}
+
+.hero-header .theme-toggle {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+}
+
+@media (min-width: 768px) {
+  .hero-header {
+    flex-direction: row;
+    justify-content: space-between;
+    text-align: left;
+  }
+  .hero-info {
+    align-items: flex-start;
+  }
+}
+
+.btn-primary {
+  display: inline-block;
+  padding: 12px 24px;
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.3s;
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  background: var(--color-secondary);
+}
+
+.btn-primary:focus-visible {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 4px;
+}
+
 .speech {
   background: var(--card-bg);
   padding: 0.5rem 1rem;
@@ -220,76 +297,99 @@ body.dark .speech-bubble {
 }
 
 
+
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 2rem;
+  gap: 32px;
   list-style: none;
   margin: 0 auto;
-  padding: 0;
-  max-width: 800px;
+  padding: 32px 16px;
+  grid-template-columns: 1fr;
+  max-width: 1200px;
 }
 
-@media (max-width: 600px) {
+@media (min-width: 600px) {
   .card-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, 1fr);
   }
+}
+
+@media (min-width: 900px) {
+  .card-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .card-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.card-grid > li {
+  display: flex;
 }
 
 .card-button {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
   background: var(--card-bg);
   border-radius: var(--card-radius);
-  padding: 2rem;
   text-decoration: none;
   color: var(--color-text);
-  font-weight: 600;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-  transition: transform 0.2s, box-shadow 0.2s, filter 0.2s;
-  min-height: 180px;
-  width: 100%;
-  text-align: center;
-}
-
-.card-icon {
-  flex: 0 0 100px;
-  height: 100px;
-  width: 100px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 16px;
   overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s, filter 0.2s;
+  width: 100%;
 }
 
-.card-icon img {
-  max-width: 100%;
-  max-height: 100%;
+.card-img {
+  width: 100%;
+  aspect-ratio: 16/9;
+  object-fit: cover;
 }
 
-.card-text {
+.card-img.placeholder {
+  background: #ddd;
+}
+
+.card-content {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   flex: 1;
   text-align: center;
 }
 
+.card-title {
+  margin: 0;
+  font-size: 1rem;
+}
 
-.card-button:not([disabled]):hover,
-.card-button:not([disabled]):focus-visible {
+.card-subtitle {
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.card-button:hover:not([disabled]),
+.card-button:focus-visible:not([disabled]) {
   transform: translateY(-4px);
-  box-shadow: 0 12px 24px rgba(0,0,0,0.3);
+  box-shadow: 0 12px 24px rgba(0,0,0,0.2);
   filter: brightness(1.05);
 }
 
-.card-button:not([disabled]):active {
+.card-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 4px;
+}
+
+.card-button:active:not([disabled]) {
   transform: scale(0.98);
 }
 
 .card-button.accent {
-  background: var(--color-secondary);
+  background: var(--color-accent);
   color: #fff;
 }
 
@@ -558,6 +658,24 @@ button:hover {
   animation: blink 1s steps(2, start) infinite;
 }
 
+.site-footer {
+  text-align: center;
+  padding: 16px;
+  font-size: 0.875rem;
+  background: #f5f5f5;
+  color: var(--color-text);
+}
+
+.site-footer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-footer a:hover,
+.site-footer a:focus-visible {
+  text-decoration: underline;
+}
+
 @keyframes blink {
   0%, 50% { opacity: 1; }
   50.01%, 100% { opacity: 0; }
@@ -725,6 +843,9 @@ body.dark-mode #themeToggle {
 @media (max-width: 480px) {
   body {
     padding-top: 90px;
+  }
+  body.home {
+    padding-top: 0;
   }
   .container.menu {
     margin: 1rem;


### PR DESCRIPTION
## Summary
- Add hero header with Certy logo, tagline and call-to-action
- Refactor home cards with responsive grid and orange paralización card
- Move download button script into common.js and add contact footer

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68a90a2a553c832e948d4636cb59e20e