### PR TITLE
feat: improve hero tagline and add wave divider

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
     <img src="Certy_logo.png" alt="Certy" class="hero-img" loading="lazy">
   </header>
 
+  <div class="wave-divider" aria-hidden="true">
+    <svg viewBox="0 0 1440 80" preserveAspectRatio="none">
+      <path d="M0,0 C480,80 960,0 1440,80 L1440,0 L0,0 Z" fill="#1F6BFF"></path>
+    </svg>
+  </div>
+
   <main>
     <nav id="servicios" aria-label="Opciones de Certy">
       <ul class="card-grid">

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Baloo+2:wght@600&display=swap');
 
 :root {
   --color-primary: #0C4FB7;
@@ -203,7 +203,8 @@ body.dark .speech-bubble {
 }
 
 .hero-claim {
-  font-size: 1.25rem;
+  font-family: 'Baloo 2', cursive;
+  font-size: 2rem;
   margin: 0;
   font-weight: 700;
   color: var(--color-primary);
@@ -220,6 +221,18 @@ body.dark .speech-bubble {
   width: 100%;
   height: auto;
   animation: float 4s ease-in-out infinite;
+}
+
+.wave-divider {
+  position: relative;
+  width: 100%;
+  line-height: 0;
+}
+
+.wave-divider svg {
+  display: block;
+  width: 100%;
+  height: 80px;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- animate hero tagline with a playful font and larger size
- insert blue wave divider to separate hero header from card grid

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a943c272d8832ebcc01035016d2da7