### PR TITLE
Enhance header styling and weather placement

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -21,10 +21,16 @@
     <button class="back-btn" onclick="window.location.href='index.html'" aria-label="Volver al menú principal"><i class="fa-solid fa-arrow-left"></i> Menú</button>
     <div class="logo-group">
       <img src="NeuquénCapital_logo.png" alt="Logo Neuquén Capital">
-      <span class="dept">Dirección Municipal de Certificaciones</span>
+      <div class="dept-group">
+        <span class="dept">Dirección Municipal de Certificaciones</span>
+        <span class="subdept">Subsecretaría de Gestión de Contrataciones de Obras Públicas</span>
+      </div>
     </div>
     <div class="header-actions">
-      <div id="weather" class="weather"></div>
+      <div class="weather-container">
+        <div id="weather" class="weather"></div>
+        <div class="city-label">Neuquén Capital</div>
+      </div>
     </div>
   </header>
 

--- a/paralizacion.html
+++ b/paralizacion.html
@@ -15,10 +15,16 @@
     <button class="back-btn" onclick="window.location.href='index.html'" aria-label="Volver al menú principal"><i class="fa-solid fa-arrow-left"></i> Menú</button>
     <div class="logo-group">
       <img src="NeuquénCapital_logo.png" alt="Logo Neuquén Capital">
-      <span class="dept">Dirección Municipal de Certificaciones</span>
+      <div class="dept-group">
+        <span class="dept">Dirección Municipal de Certificaciones</span>
+        <span class="subdept">Subsecretaría de Gestión de Contrataciones de Obras Públicas</span>
+      </div>
     </div>
     <div class="header-actions">
-      <div id="weather" class="weather"></div>
+      <div class="weather-container">
+        <div id="weather" class="weather"></div>
+        <div class="city-label">Neuquén Capital</div>
+      </div>
     </div>
   </header>
 

--- a/project.html
+++ b/project.html
@@ -21,10 +21,16 @@
     <button class="back-btn" onclick="window.location.href='index.html'" aria-label="Volver al menú principal"><i class="fa-solid fa-arrow-left"></i> Menú</button>
     <div class="logo-group">
       <img src="NeuquénCapital_logo.png" alt="Logo Neuquén Capital">
-      <span class="dept">Dirección Municipal de Certificaciones</span>
+      <div class="dept-group">
+        <span class="dept">Dirección Municipal de Certificaciones</span>
+        <span class="subdept">Subsecretaría de Gestión de Contrataciones de Obras Públicas</span>
+      </div>
     </div>
     <div class="header-actions">
-      <div id="weather" class="weather"></div>
+      <div class="weather-container">
+        <div id="weather" class="weather"></div>
+        <div class="city-label">Neuquén Capital</div>
+      </div>
     </div>
   </header>
 

--- a/styles.css
+++ b/styles.css
@@ -62,14 +62,34 @@ body.dark .site-header {
   height: 60px;
 }
 
+.logo-group .dept-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
 .logo-group .dept {
   font-weight: 600;
+}
+
+.logo-group .subdept {
+  font-size: 0.7rem;
+  color: #555;
+  text-align: center;
 }
 
 .header-actions {
   display: flex;
   align-items: center;
   gap: 1rem;
+  margin-right: 1rem;
+}
+
+.weather-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .weather {
@@ -77,6 +97,11 @@ body.dark .site-header {
   align-items: center;
   gap: 0.25rem;
   font-weight: 600;
+  color: var(--color-text);
+}
+
+.city-label {
+  font-size: 0.75rem;
   color: var(--color-text);
 }
 
@@ -115,6 +140,11 @@ body.dark .site-header {
 
 .back-btn i {
   font-size: 1.5rem;
+}
+
+.back-btn:hover,
+.back-btn:hover i {
+  text-shadow: 0 0 4px rgba(0,0,0,0.3);
 }
 
 .container {


### PR DESCRIPTION
## Summary
- Center logo group text and add new Subsecretaría line in header
- Give back button a subtle grey text shadow on hover
- Reposition weather block and add "Neuquén Capital" label

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9d5d08f8c832e816a8de7e888289b