### PR TITLE
Improve report styling and PDF generation

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -75,7 +75,10 @@
     </div>
 
     <div id="result"></div>
-    <button id="printBtn" onclick="openPdfReport()" style="display:none;">🖨 Imprimir informe en PDF</button>
+    <div id="printSection" style="display:none;">
+      <button id="printBtn" onclick="openPdfReport()">🖨 Imprimir informe en PDF</button>
+      <img src="Certy_fotos.png" alt="Certy" />
+    </div>
       </div>
     </div>
 

--- a/project.html
+++ b/project.html
@@ -74,7 +74,10 @@
     </div>
 
     <div id="result"></div>
-    <button id="printBtn" onclick="openPdfReport()" style="display:none;">🖨 Imprimir informe en PDF</button>
+    <div id="printSection" style="display:none;">
+      <button id="printBtn" onclick="openPdfReport()">🖨 Imprimir informe en PDF</button>
+      <img src="Certy_fotos.png" alt="Certy" />
+    </div>
     </div>
   </div>
 

--- a/project.js
+++ b/project.js
@@ -192,7 +192,7 @@ function calculate() {
 
   let currentDate = addDays(startDate, initialDays - 1);
 
-  let resultHTML = `<h2 class="report-title">REPORTE GENERADO POR LA APP CERTY</h2>`;
+  let resultHTML = `<h2 class="report-title">REPORTE GENERADO POR CERTY</h2>`;
   resultHTML += `<p><strong>Fecha de inicio:</strong> ${formatDate(startDate)}</p>`;
   resultHTML += `<p><strong>Plazo inicial:</strong> ${initialDays} días</p>`;
 
@@ -231,7 +231,7 @@ function calculate() {
   resultEl.innerHTML = resultHTML;
   const calendarHTML = generateCalendar(startDate, currentDate, suspensions, pauses);
   resultEl.insertAdjacentHTML('beforeend', calendarHTML);
-  document.getElementById('printBtn').style.display = 'block';
+  document.getElementById('printSection').style.display = 'flex';
 }
 
 function clearAll() {
@@ -242,7 +242,7 @@ function clearAll() {
   document.getElementById('suspensionSection').innerHTML = '';
   document.getElementById('pauseSection').innerHTML = '';
   document.getElementById('result').innerHTML = '';
-  document.getElementById('printBtn').style.display = 'none';
+  document.getElementById('printSection').style.display = 'none';
 }
 
 async function openPdfReport() {
@@ -269,14 +269,8 @@ async function openPdfReport() {
 
   const pdfWindow = window.open('', '_blank');
   const { jsPDF } = window.jspdf;
-  const doc = new jsPDF({ unit: 'pt', format: 'a4' });
+  const doc = new jsPDF({ unit: 'pt', format: 'a4', lineHeightFactor: 1.5 });
 
-
-  const originalFont = resultEl.style.fontFamily;
-  const originalLig = resultEl.style.fontVariantLigatures;
-  const originalSize = resultEl.style.fontSize;
-  const originalWordSpacing = resultEl.style.wordSpacing;
-  const originalLetterSpacing = resultEl.style.letterSpacing;
   const originalStyles = new Map();
   const elements = resultEl.getElementsByTagName('*');
   for (let el of elements) {
@@ -290,11 +284,7 @@ async function openPdfReport() {
     }
   }
 
-  resultEl.style.fontFamily = '"Courier New", monospace';
-  resultEl.style.fontVariantLigatures = 'none';
-  resultEl.style.fontSize = '12pt';
-
-  doc.setFont('courier', 'normal');
+  doc.setFont('helvetica', 'normal');
 
   doc.html(resultEl, {
     margin: [40, 40, 40, 40],
@@ -306,18 +296,13 @@ async function openPdfReport() {
     callback: function (doc) {
       const pageH = doc.internal.pageSize.getHeight();
       const pageW = doc.internal.pageSize.getWidth();
-      doc.setFont('courier', 'italic');
+      doc.setFont('helvetica', 'italic');
 
       const finalize = () => {
         for (const [el, styles] of originalStyles.entries()) {
           el.style.color = styles.color;
           el.style.backgroundColor = styles.backgroundColor;
         }
-        resultEl.style.fontFamily = originalFont;
-        resultEl.style.fontVariantLigatures = originalLig;
-        resultEl.style.fontSize = originalSize;
-        resultEl.style.wordSpacing = originalWordSpacing;
-        resultEl.style.letterSpacing = originalLetterSpacing;
         resultEl.classList.remove('pdf-export');
 
         const blob = doc.output('blob');

--- a/script.js
+++ b/script.js
@@ -185,7 +185,7 @@ function calculate() {
   const finalDate = addDays(startDate, initialDays - 1);
   let currentDate = new Date(finalDate);
 
-  let resultHTML = `<h2 class="report-title">REPORTE GENERADO POR LA APP CERTY</h2>`;
+  let resultHTML = `<h2 class="report-title">REPORTE GENERADO POR CERTY</h2>`;
   resultHTML += `<p><strong>Fecha de inicio:</strong> ${formatDate(startDate)}</p>`;
   resultHTML += `<p><strong>Plazo inicial:</strong> ${initialDays} días</p>`;
 
@@ -241,7 +241,7 @@ function calculate() {
   resultHTML += generarTablaFojas(startDate, currentDate, pauses);
 
   document.getElementById("result").innerHTML = resultHTML;
-    document.getElementById('printBtn').style.display = 'block';
+    document.getElementById('printSection').style.display = 'flex';
 }
 
 function clearAll() {
@@ -252,7 +252,7 @@ function clearAll() {
   document.getElementById('pauseSection').innerHTML = '';
   document.getElementById('extensionSection').innerHTML = '';
   document.getElementById('result').innerHTML = '';
-    document.getElementById('printBtn').style.display = 'none';
+    document.getElementById('printSection').style.display = 'none';
 }
 
 async function openPdfReport() {
@@ -278,20 +278,7 @@ async function openPdfReport() {
   }
   const pdfWindow = window.open('', '_blank');
   const { jsPDF } = window.jspdf;
-  const doc = new jsPDF({ unit: 'pt', format: 'a4' });
-  const originalWordSpacing = resultEl.style.wordSpacing;
-  const originalLetterSpacing = resultEl.style.letterSpacing;
-  const textNodes = [];
-  const walker = document.createTreeWalker(resultEl, NodeFilter.SHOW_TEXT, null, false);
-  while (walker.nextNode()) {
-    const node = walker.currentNode;
-    if (node.nodeValue.includes(':')) {
-      textNodes.push({ node, text: node.nodeValue });
-      node.nodeValue = node.nodeValue.replace(/:/g, ' :');
-    }
-  }
-  resultEl.style.wordSpacing = '4px';
-  resultEl.style.letterSpacing = '1px';
+  const doc = new jsPDF({ unit: 'pt', format: 'a4', lineHeightFactor: 1.5 });
 
   // Save original styles using a Map to restore them later
   const originalStyles = new Map();
@@ -327,9 +314,6 @@ async function openPdfReport() {
           el.style.color = styles.color;
           el.style.backgroundColor = styles.backgroundColor;
         }
-        textNodes.forEach(({ node, text }) => (node.nodeValue = text));
-        resultEl.style.wordSpacing = originalWordSpacing;
-        resultEl.style.letterSpacing = originalLetterSpacing;
         resultEl.classList.remove('pdf-export');
 
         const blob = doc.output('blob');

--- a/styles.css
+++ b/styles.css
@@ -83,7 +83,7 @@ body.dark .site-header {
   display: flex;
   align-items: center;
   gap: 1rem;
-  margin-right: 1rem;
+  margin-right: 2rem;
 }
 
 .weather-container {
@@ -136,6 +136,7 @@ body.dark .site-header {
   cursor: pointer;
   margin-right: 0.5rem;
   color: var(--color-primary);
+  outline: none;
 }
 
 .back-btn i {
@@ -145,6 +146,12 @@ body.dark .site-header {
 .back-btn:hover,
 .back-btn:hover i {
   text-shadow: 0 0 4px rgba(0,0,0,0.3);
+}
+
+.back-btn:focus,
+.back-btn:active {
+  outline: none;
+  box-shadow: none;
 }
 
 .container {
@@ -678,7 +685,24 @@ button:hover {
 
 #printBtn {
   display: block;
+}
+
+#result,
+#result * {
+  font-family: 'Poppins', sans-serif;
+  line-height: 1.5;
+}
+
+#printSection {
+  display: none;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
   margin: 2rem auto 0;
+}
+
+#printSection img {
+  height: 2.5em;
 }
 
 
@@ -769,8 +793,8 @@ body.dark-mode img {
 .report-title {
   text-align: center;
   text-decoration: underline;
-  letter-spacing: 2px;
-  word-spacing: 4px;
+  font-weight: 600;
+  line-height: 1.5;
 }
 
 .suggestion {


### PR DESCRIPTION
## Summary
- Remove focus outline from back button and expand header spacing for weather widget
- Standardize report typography and title wording across pages
- Add Certy logo to PDF print section and simplify PDF generation with consistent line-height

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9dc93393c832eb060eb65fe6c6f19