### PR TITLE
Improve report styling and footer visuals

### DIFF
--- a/project.js
+++ b/project.js
@@ -284,7 +284,8 @@ async function openPdfReport() {
     }
   }
 
-  doc.setFont('helvetica', 'normal');
+  doc.setFont('Arial', 'normal');
+  doc.setCharSpace(0.5);
 
   doc.html(resultEl, {
     margin: [40, 40, 40, 40],
@@ -296,7 +297,10 @@ async function openPdfReport() {
     callback: function (doc) {
       const pageH = doc.internal.pageSize.getHeight();
       const pageW = doc.internal.pageSize.getWidth();
-      doc.setFont('helvetica', 'italic');
+      doc.setFontSize(12);
+      doc.setFont('Arial', 'normal');
+      doc.setCharSpace(0.5);
+      doc.setTextColor(0, 0, 0);
 
       const finalize = () => {
         for (const [el, styles] of originalStyles.entries()) {
@@ -311,14 +315,15 @@ async function openPdfReport() {
       };
 
       const img = new Image();
-      img.src = 'Certy_saludando.png';
+      img.src = 'Robot.png';
       img.onload = function() {
-        const imgSize = 32;
+        const imgSize = 32 * 1.2;
         const xImg = pageW - 40 - imgSize;
         const yImg = pageH - imgSize - 20;
         doc.addImage(img, 'PNG', xImg, yImg, imgSize, imgSize);
-        const textX = xImg - 5;
-        doc.text('Gracias por usar la app de Certy!', textX, pageH - 20, { align: 'right' });
+        doc.setFont('Arial', 'italic');
+        const textX = xImg - 10;
+        doc.text('Gracias por usar Certy!', textX, pageH - 20, { align: 'right' });
         finalize();
       };
       img.onerror = finalize;

--- a/script.js
+++ b/script.js
@@ -294,6 +294,9 @@ async function openPdfReport() {
     }
   }
 
+  doc.setFont('Arial', 'normal');
+  doc.setCharSpace(0.5);
+
   doc.html(resultEl, {
     margin: [40, 40, 60, 40],
     html2canvas: {
@@ -305,8 +308,8 @@ async function openPdfReport() {
       const pageH = doc.internal.pageSize.getHeight();
       const pageW = doc.internal.pageSize.getWidth();
       doc.setFontSize(12);
-      doc.setFont('helvetica', 'normal');
-      doc.setCharSpace(1);
+      doc.setFont('Arial', 'normal');
+      doc.setCharSpace(0.5);
       doc.setTextColor(0, 0, 0); // Black text
 
       const finalize = () => {
@@ -326,14 +329,15 @@ async function openPdfReport() {
       };
 
       const img = new Image();
-      img.src = 'Certy_saludando.png';
+      img.src = 'Robot.png';
       img.onload = function() {
-        const imgSize = 16;
+        const imgSize = 16 * 1.2;
         const xImg = pageW - 40 - imgSize;
         const yImg = pageH - imgSize - 20;
         doc.addImage(img, 'PNG', xImg, yImg, imgSize, imgSize);
-        const textX = xImg - 5;
-        doc.text('Gracias por usar la app de Certy!', textX, pageH - 20, { align: 'right' });
+        doc.setFont('Arial', 'italic');
+        const textX = xImg - 10;
+        doc.text('Gracias por usar Certy!', textX, pageH - 20, { align: 'right' });
         finalize();
       };
       img.onerror = finalize;

--- a/styles.css
+++ b/styles.css
@@ -925,19 +925,42 @@ body.dark-mode img {
   width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: Arial, Calibri, sans-serif;
 }
 
 .fojas-table th,
 .fojas-table td {
   border: 1px solid #000;
-  padding: 8px;
+  padding: 6pt;
   height: 24px;
   text-align: center;
 }
 
 .fojas-table td.num {
   text-align: center;
+}
+
+.pdf-export {
+  font-family: Arial, Calibri, sans-serif;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  word-spacing: 2px;
+}
+
+.pdf-export table {
+  border-collapse: collapse;
+  margin: 10px;
+}
+
+.pdf-export th,
+.pdf-export td {
+  padding: 6pt;
+}
+
+.report-title {
+  text-transform: uppercase;
+  text-align: center;
+  margin-bottom: 20px;
 }
 @media (max-width: 480px) {
   body {


### PR DESCRIPTION
## Summary
- Refine report CSS to use Arial/Calibri with spacing to prevent text overlap, standardized table formatting, and centered uppercase titles.
- Update PDF generation scripts to render an italic "Gracias por usar Certy!" footer alongside an enlarged robot logo.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9f61d4a00832ebed16bb36488e238