### PR TITLE
Actualizar contenedor de reporte y cambiar ícono inferior

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -74,10 +74,10 @@
       <button onclick="clearAll()">🗑 Borrar</button>
     </div>
 
-    <div id="result"></div>
+    <div id="reporte"></div>
     <div id="printSection" style="display:none;">
       <button id="printBtn" onclick="openPdfReport()">🖨 Imprimir informe en PDF</button>
-      <img src="Certy_fotos.png" alt="Certy" />
+      <img src="Certy_saludando.png" alt="Certy" />
     </div>
       </div>
     </div>

--- a/project.html
+++ b/project.html
@@ -73,10 +73,10 @@
       <button onclick="clearAll()">🗑 Borrar</button>
     </div>
 
-    <div id="result"></div>
+    <div id="reporte"></div>
     <div id="printSection" style="display:none;">
       <button id="printBtn" onclick="openPdfReport()">🖨 Imprimir informe en PDF</button>
-      <img src="Certy_fotos.png" alt="Certy" />
+      <img src="Certy_saludando.png" alt="Certy" />
     </div>
     </div>
   </div>

--- a/project.js
+++ b/project.js
@@ -192,7 +192,7 @@ function calculate() {
 
   let currentDate = addDays(startDate, initialDays - 1);
 
-  let resultHTML = `<h2 class="report-title">REPORTE GENERADO POR CERTY</h2>`;
+  let resultHTML = `<h1>REPORTE GENERADO POR CERTY</h1>`;
   resultHTML += `<p><strong>Fecha de inicio:</strong> ${formatDate(startDate)}</p>`;
   resultHTML += `<p><strong>Plazo inicial:</strong> ${initialDays} días</p>`;
 
@@ -227,7 +227,7 @@ function calculate() {
   resultHTML += `<p><strong>Foja Nº Final:</strong> ${fojas.length} FINAL</p>`;
   resultHTML += generarTablaFojas(fojas);
 
-  const resultEl = document.getElementById("result");
+  const resultEl = document.getElementById("reporte");
   resultEl.innerHTML = resultHTML;
   const calendarHTML = generateCalendar(startDate, currentDate, suspensions, pauses);
   resultEl.insertAdjacentHTML('beforeend', calendarHTML);
@@ -241,12 +241,12 @@ function clearAll() {
   document.getElementById('hasPauses').value = 'no';
   document.getElementById('suspensionSection').innerHTML = '';
   document.getElementById('pauseSection').innerHTML = '';
-  document.getElementById('result').innerHTML = '';
+  document.getElementById('reporte').innerHTML = '';
   document.getElementById('printSection').style.display = 'none';
 }
 
 async function openPdfReport() {
-  const resultEl = document.getElementById('result');
+  const resultEl = document.getElementById('reporte');
 
   resultEl.classList.add('pdf-export');
 

--- a/script.js
+++ b/script.js
@@ -185,7 +185,7 @@ function calculate() {
   const finalDate = addDays(startDate, initialDays - 1);
   let currentDate = new Date(finalDate);
 
-  let resultHTML = `<h2 class="report-title">REPORTE GENERADO POR CERTY</h2>`;
+  let resultHTML = `<h1>REPORTE GENERADO POR CERTY</h1>`;
   resultHTML += `<p><strong>Fecha de inicio:</strong> ${formatDate(startDate)}</p>`;
   resultHTML += `<p><strong>Plazo inicial:</strong> ${initialDays} días</p>`;
 
@@ -240,7 +240,7 @@ function calculate() {
   }
   resultHTML += generarTablaFojas(startDate, currentDate, pauses);
 
-  document.getElementById("result").innerHTML = resultHTML;
+  document.getElementById("reporte").innerHTML = resultHTML;
     document.getElementById('printSection').style.display = 'flex';
 }
 
@@ -251,12 +251,12 @@ function clearAll() {
   document.getElementById('hasExtension').value = 'no';
   document.getElementById('pauseSection').innerHTML = '';
   document.getElementById('extensionSection').innerHTML = '';
-  document.getElementById('result').innerHTML = '';
+  document.getElementById('reporte').innerHTML = '';
     document.getElementById('printSection').style.display = 'none';
 }
 
 async function openPdfReport() {
-  const resultEl = document.getElementById('result');
+  const resultEl = document.getElementById('reporte');
 
   resultEl.classList.add('pdf-export');
 

--- a/styles.css
+++ b/styles.css
@@ -687,12 +687,6 @@ button:hover {
   display: block;
 }
 
-#result,
-#result * {
-  font-family: 'Poppins', sans-serif;
-  line-height: 1.5;
-}
-
 #printSection {
   display: none;
   justify-content: center;
@@ -980,4 +974,60 @@ body.dark-mode img {
   .menu h1 {
     font-size: 1.2rem;
   }
+}
+
+/* Reporte Certy – formato estable para ver e imprimir */
+#reporte {
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.5;
+  letter-spacing: 0.3px;
+  word-spacing: 1px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-size: 12pt;
+  max-width: 180mm;
+  margin: 0 auto;
+}
+
+#reporte h1 {
+  text-align: center;
+  font-weight: 700;
+  margin: 8mm 0 6mm;
+  letter-spacing: 0.6px;
+  text-decoration: underline;
+}
+
+#reporte .bloque { margin: 4mm 0; }
+#reporte .bloque p { margin: 2mm 0; }
+#reporte .bloque strong { display: inline-block; min-width: 55mm; }
+
+#reporte table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+#reporte th,
+#reporte td {
+  border: 1pt solid #999;
+  padding: 6pt;
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+
+#reporte th { font-weight: 700; }
+
+#reporte * { hyphens: none; }
+#reporte p,
+#reporte td,
+#reporte th {
+  white-space: normal;
+  word-break: keep-all;
+  text-align: left;
+}
+
+@page { size: A4; margin: 18mm; }
+@media print {
+  #reporte { max-width: none; }
+  a { text-decoration: none; color: black; }
 }


### PR DESCRIPTION
## Resumen
- Reemplazar ícono final por **Certy_saludando.png**
- Renombrar contenedor de resultados a `#reporte` y aplicar estilo de impresión con Arial 12pt
- Ajustar generación de reportes en JS para usar el nuevo contenedor y encabezado `<h1>`

## Pruebas
- `npm test` *(sin pruebas configuradas)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f9d4d078832e865c32cf96f89a7f