### PR TITLE
Ajustar icono y formato de informes

### DIFF
--- a/paralizacion.html
+++ b/paralizacion.html
@@ -93,7 +93,7 @@
         <div class="button-row">
           <button id="generarSugerencia" type="button" class="sugerencia-btn">⚙️ Generar</button>
         </div>
-        <label for="textoSugerido">Texto sugerido por Certy! <img src="Robot.png" alt="Robot" class="robot-icon" /></label>
+        <label for="textoSugerido">Texto sugerido por Certy! <img src="Certy_saludando.png" alt="Certy saludando" class="robot-icon" /></label>
         <p class="suggestion-note"><strong><em>No olvides editarlo, copiarlo y pegarlo en "Motivo de la paralización" mas arriba 👆</em></strong></p>
         <textarea id="textoSugerido" rows="6"></textarea>
       </div>

--- a/project.js
+++ b/project.js
@@ -299,7 +299,7 @@ async function openPdfReport() {
       const pageW = doc.internal.pageSize.getWidth();
       doc.setFontSize(12);
       doc.setFont('Arial', 'normal');
-      doc.setCharSpace(0.5);
+      doc.setCharSpace(0);
       doc.setTextColor(0, 0, 0);
 
       const finalize = () => {
@@ -315,7 +315,7 @@ async function openPdfReport() {
       };
 
       const img = new Image();
-      img.src = 'Robot.png';
+      img.src = 'Certy_saludando.png';
       img.onload = function() {
         const imgSize = 32 * 1.2;
         const xImg = pageW - 40 - imgSize;

--- a/script.js
+++ b/script.js
@@ -309,7 +309,7 @@ async function openPdfReport() {
       const pageW = doc.internal.pageSize.getWidth();
       doc.setFontSize(12);
       doc.setFont('Arial', 'normal');
-      doc.setCharSpace(0.5);
+      doc.setCharSpace(0);
       doc.setTextColor(0, 0, 0); // Black text
 
       const finalize = () => {
@@ -329,7 +329,7 @@ async function openPdfReport() {
       };
 
       const img = new Image();
-      img.src = 'Robot.png';
+      img.src = 'Certy_saludando.png';
       img.onload = function() {
         const imgSize = 16 * 1.2;
         const xImg = pageW - 40 - imgSize;

--- a/styles.css
+++ b/styles.css
@@ -937,8 +937,6 @@ body.dark-mode img {
 .pdf-export {
   font-family: Arial, Calibri, sans-serif;
   line-height: 1.5;
-  letter-spacing: 0.5px;
-  word-spacing: 2px;
 }
 
 .pdf-export table {
@@ -980,8 +978,6 @@ body.dark-mode img {
 #reporte {
   font-family: Arial, Helvetica, sans-serif;
   line-height: 1.5;
-  letter-spacing: 0.3px;
-  word-spacing: 1px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-size: 12pt;
@@ -992,9 +988,9 @@ body.dark-mode img {
 #reporte h1 {
   text-align: center;
   font-weight: 700;
-  margin: 8mm 0 6mm;
-  letter-spacing: 0.6px;
-  text-decoration: underline;
+  margin: 8mm auto 6mm;
+  border-bottom: 1px solid black;
+  display: inline-block;
 }
 
 #reporte .bloque { margin: 4mm 0; }


### PR DESCRIPTION
## Summary
- Reemplaza el ícono del pie de los informes PDF por `Certy_saludando.png` y elimina espaciado de caracteres.
- Ajusta estilos de reportes eliminando letter/word spacing global y centrando el título con borde inferior.
- Actualiza referencia en formularios a `Certy_saludando.png`.

## Testing
- `npm test` *(falla: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa0405fb24832ea2f324b7c5bb358d