### PR TITLE
Refine warning visuals and calendar colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 
   <div class="wave-divider" aria-hidden="true">
     <svg viewBox="0 0 1440 80" preserveAspectRatio="none">
-      <path d="M0,0 C480,80 960,0 1440,80 L1440,0 L0,0 Z" fill="#1F6BFF"></path>
+      <path d="M0,0 C480,80 960,0 1440,80 L1440,0 L0,0 Z" fill="#0C4FB7"></path>
     </svg>
   </div>
 

--- a/project.js
+++ b/project.js
@@ -21,7 +21,7 @@ function formatISO(date) {
 
 function buildFojas(startDate, finalDate, suspensions = []) {
   const fojas = [];
-  const sorted = suspensions.sort((a, b) => a[0] - b[0]);
+  const sorted = [...suspensions].sort((a, b) => a[0] - b[0]);
   let currentStart = new Date(startDate);
 
   while (currentStart <= finalDate) {

--- a/script.js
+++ b/script.js
@@ -155,7 +155,8 @@ function calculate() {
 
       if (pauseStart < startDate) {
         Swal.fire({
-          icon: 'error',
+          imageUrl: 'Certy_advertencia.png',
+          imageAlt: 'Advertencia',
           text: 'La paralización no puede tener fecha anterior al de inicio de la obra. Revise los datos.',
           timer: 5000,
           timerProgressBar: true
@@ -172,7 +173,8 @@ function calculate() {
     for (let i = 1; i < pauses.length; i++) {
       if (pauses[i][0] <= pauses[i - 1][1]) {
         Swal.fire({
-          icon: 'error',
+          imageUrl: 'Certy_advertencia.png',
+          imageAlt: 'Advertencia',
           text: 'Los plazos de las paralizaciones se solapan, corregir.',
           timer: 5000,
           timerProgressBar: true

--- a/styles.css
+++ b/styles.css
@@ -861,12 +861,12 @@ body.dark-mode img {
 }
 
 .work-day {
-  background: var(--color-accent);
+  background: #f58b2a;
   color: #fff;
 }
 
 .suspension-day {
-  background: var(--color-primary);
+  background: #2a7ff5;
   color: #fff;
 }
 
@@ -894,7 +894,7 @@ body.dark-mode img {
 }
 
 .pdf-export .suspension-day {
-  background: var(--color-primary) !important;
+  background: #2a7ff5 !important;
   color: #fff !important;
 }
 


### PR DESCRIPTION
## Summary
- Match menu wave divider with hero text blue tone
- Show Certy warning logo in SweetAlert errors instead of default icon
- Keep suspension array immutable when building fojas and style calendar days in blue and orange

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abc6a00828832eb1a69eb56f4556e9