### PR TITLE
Resize warning icon and highlight measurement day

### DIFF
--- a/project.js
+++ b/project.js
@@ -116,7 +116,7 @@ function generateCalendar(startDate, endDate, suspensions = [], pauses = []) {
       if (currentDay >= startDate && currentDay <= endDate) {
         if (isSuspension(currentDay)) className = 'suspension-day';
         else if (isPause(currentDay)) className = 'pause-day';
-        else if (isMeasurement(currentDay)) className = '';
+        else if (isMeasurement(currentDay)) className = 'measurement-day';
         else className = 'work-day';
       }
       html += `<td class="${className}">${day}</td>`;

--- a/script.js
+++ b/script.js
@@ -157,6 +157,8 @@ function calculate() {
         Swal.fire({
           imageUrl: 'Certy_advertencia.png',
           imageAlt: 'Advertencia',
+          imageWidth: 202,
+          imageHeight: 252,
           text: 'La paralización no puede tener fecha anterior al de inicio de la obra. Revise los datos.',
           timer: 5000,
           timerProgressBar: true
@@ -175,6 +177,8 @@ function calculate() {
         Swal.fire({
           imageUrl: 'Certy_advertencia.png',
           imageAlt: 'Advertencia',
+          imageWidth: 202,
+          imageHeight: 252,
           text: 'Los plazos de las paralizaciones se solapan, corregir.',
           timer: 5000,
           timerProgressBar: true

--- a/styles.css
+++ b/styles.css
@@ -883,6 +883,11 @@ body.dark-mode img {
   color: #fff;
 }
 
+.measurement-day {
+  background: #28a745;
+  color: #fff;
+}
+
 .pdf-export .work-day {
   background: #d3d3d3 !important;
   color: #000 !important;
@@ -896,6 +901,11 @@ body.dark-mode img {
 .pdf-export .suspension-day {
   background: #2a7ff5 !important;
   color: #fff !important;
+}
+
+.pdf-export .measurement-day {
+  background: #d3d3d3 !important;
+  color: #000 !important;
 }
 
 .pdf-export .calendar {


### PR DESCRIPTION
## Summary
- Shrink Certy_advertencia warning image to half size in alerts
- Highlight measurement/next-day after suspensions and pauses in calendar using green style

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abca44f244832ea583cea07e526507