### PR TITLE
Diferencia suspensiones y paralizaciones en generador de fojas

### DIFF
--- a/project.js
+++ b/project.js
@@ -19,32 +19,48 @@ function formatISO(date) {
   return date.toISOString().split('T')[0];
 }
 
-function addWorkingDays(startDate, targetWorkedDays, nonWorking = []) {
-  const ranges = [...nonWorking].sort((a, b) => a[0] - b[0]);
-  let worked = 0;
-  let current = new Date(startDate);
-  while (true) {
-    const isNonWorking = ranges.some(([s, e]) => current >= s && current <= e);
-    if (!isNonWorking) {
-      worked++;
-      if (worked === targetWorkedDays) break;
-    }
-    current = addDays(current, 1);
-  }
-  return current;
-}
-
-function buildFojas(startDate, totalWorkedDays, nonWorking = []) {
+function buildFojas(startDate, totalWorkedDays, suspensions = [], pauses = []) {
   const fojas = [];
-  let remaining = totalWorkedDays;
-  let currentStart = new Date(startDate);
-  while (remaining > 0) {
-    const chunk = Math.min(30, remaining);
-    const end = addWorkingDays(currentStart, chunk, nonWorking);
-    fojas.push({ desde: new Date(currentStart), hasta: new Date(end) });
-    remaining -= chunk;
-    currentStart = addDays(end, 1);
+  let currentDate = new Date(startDate);
+  let remaining = 30;
+  let worked = 0;
+  let fojaStart = null;
+
+  const isSuspension = date => suspensions.some(([s, e]) => date >= s && date <= e);
+  const getPause = date => pauses.find(([s, e]) => date >= s && date <= e);
+
+  while (worked < totalWorkedDays) {
+    const pause = getPause(currentDate);
+    if (pause) {
+      if (fojaStart && remaining < 30) {
+        const end = addDays(currentDate, -1);
+        fojas.push({ desde: new Date(fojaStart), hasta: end });
+      }
+      fojaStart = null;
+      currentDate = addDays(pause[1], 1);
+      continue;
+    }
+
+    if (isSuspension(currentDate)) {
+      currentDate = addDays(currentDate, 1);
+      continue;
+    }
+
+    if (!fojaStart) fojaStart = new Date(currentDate);
+
+    worked++;
+    remaining--;
+
+    const end = new Date(currentDate);
+    if (remaining === 0 || worked === totalWorkedDays) {
+      fojas.push({ desde: new Date(fojaStart), hasta: end });
+      remaining = 30;
+      fojaStart = null;
+    }
+
+    currentDate = addDays(currentDate, 1);
   }
+
   return fojas;
 }
 
@@ -213,8 +229,7 @@ function calculate() {
     resultHTML += `<p><strong>Paralizaciones:</strong> No hubo</p>`;
   }
 
-  const nonWorking = [...suspensions, ...pauses];
-  const fojas = buildFojas(startDate, initialDays, nonWorking);
+  const fojas = buildFojas(startDate, initialDays, suspensions, pauses);
   const finalDate = fojas[fojas.length - 1].hasta;
 
   resultHTML += '<hr />';

--- a/styles.css
+++ b/styles.css
@@ -879,13 +879,15 @@ body.dark-mode img {
 }
 
 .pause-day {
-  background: #2a7ff5;
+  background: #dc3545;
   color: #fff;
 }
 
 .measurement-day {
-  background: #f58b2a;
+  background: #28a745;
   color: #fff;
+  border: 2px solid #f58b2a;
+  box-sizing: border-box;
 }
 
 .pdf-export .work-day {
@@ -894,7 +896,7 @@ body.dark-mode img {
 }
 
 .pdf-export .pause-day {
-  background: #2a7ff5 !important;
+  background: #dc3545 !important;
   color: #fff !important;
 }
 
@@ -906,6 +908,8 @@ body.dark-mode img {
 .pdf-export .measurement-day {
   background: #d3d3d3 !important;
   color: #000 !important;
+  border: 2px solid #f58b2a;
+  box-sizing: border-box;
 }
 
 .pdf-export .calendar {


### PR DESCRIPTION
## Summary
- Generador de fojas recorre el cronograma día por día y corta la foja ante paralizaciones manteniendo el saldo pendiente del ciclo de 30 días.
- Las paralizaciones se pintan en rojo y los días de medición ahora muestran borde sobre el color de trabajo.

## Testing
- `node --check project.js`
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const sandbox = {window:{addEventListener:()=>{}}, document:{getElementById:()=>({addEventListener:()=>{}, value:'', innerHTML:'', style:{}}), querySelector:()=>null, querySelectorAll:()=>[]}, console};
vm.createContext(sandbox);
vm.runInContext(fs.readFileSync('project.js','utf8'), sandbox);
const {buildFojas} = sandbox;
const d = (str)=>{const [day,month,year]=str.split('/').map(Number);return new Date(year,month-1,day);};
console.log('A',buildFojas(d('01/08/2024'),30,[[d('10/08/2024'),d('15/08/2024')]],[[d('31/08/2024'),d('20/09/2024')]]));
console.log('B',buildFojas(d('01/08/2024'),30,[[d('10/08/2024'),d('20/08/2024')]],[]));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ad017b80bc832ea1864a9498fd65a0