### PR TITLE
feat: foja-based suspension suggestions

### DIFF
--- a/project.html
+++ b/project.html
@@ -50,13 +50,6 @@
       <input type="number" id="initialDays" placeholder="Cantidad" />
     </label>
 
-    <label>Sugerir a partir de:
-      <select id="suspensionAnchor">
-        <option value="start">Inicio de obra</option>
-        <option value="last">Último evento</option>
-      </select>
-    </label>
-
     <label>¿Hubo suspensiones?
       <select id="hasSuspensions">
         <option value="no">No</option>

--- a/project.js
+++ b/project.js
@@ -83,17 +83,15 @@ function generarTablaFojas(fojas) {
     <h3>Detalle de Fojas</h3>
     <table class="fojas-table">
       <colgroup>
-        <col style="width:25%">
-        <col style="width:25%">
-        <col style="width:25%">
-        <col style="width:25%">
+        <col style="width:33.33%">
+        <col style="width:33.33%">
+        <col style="width:33.33%">
       </colgroup>
       <thead>
         <tr>
           <th>Foja Nº</th>
           <th>Desde</th>
           <th>Fecha de medición</th>
-          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -106,7 +104,6 @@ function generarTablaFojas(fojas) {
         <td class="num">${label}</td>
         <td>${formatDate(foja.desde)}</td>
         <td>${formatDate(foja.hasta)}</td>
-        <td><button type="button" onclick="suggestSuspensionFromFoja(${index + 1})">Sugerir suspensión desde esta foja</button></td>
       </tr>
     `;
   });
@@ -417,11 +414,16 @@ document.getElementById("hasSuspensions").addEventListener("change", function ()
       <label>Cantidad de suspensiones:
         <input type="number" id="suspensionCount" min="1" value="1" />
       </label>
+      <label>Foja para sugerencia:
+        <select id="suspensionAnchor"></select>
+      </label>
       <div id="suspensionsContainer"></div>
     `;
 
     const countInput = document.getElementById("suspensionCount");
     const container = document.getElementById("suspensionsContainer");
+    const anchorSelect = document.getElementById("suspensionAnchor");
+    anchorSelect.addEventListener('change', updateSuspensionSuggestions);
 
     function renderSuspensionInputs() {
       const count = parseInt(countInput.value) || 0;
@@ -458,7 +460,6 @@ document.getElementById("hasSuspensions").addEventListener("change", function ()
 
 document.getElementById('startDate').addEventListener('change', updateSuspensionSuggestions);
 document.getElementById('initialDays').addEventListener('input', updateSuspensionSuggestions);
-document.getElementById('suspensionAnchor').addEventListener('change', updateSuspensionSuggestions);
 
 function updateSuspensionSuggestions() {
   const rawStart = document.getElementById('startDate').value;
@@ -500,9 +501,7 @@ function updateSuspensionSuggestions() {
 
   if (!startDate || isNaN(initialVal)) {
     if (anchorSelect) {
-      Array.from(anchorSelect.options).forEach(o => {
-        if (o.value.startsWith('foja-')) anchorSelect.removeChild(o);
-      });
+      anchorSelect.innerHTML = '';
     }
     return;
   }
@@ -511,9 +510,7 @@ function updateSuspensionSuggestions() {
 
   if (anchorSelect) {
     const current = anchorSelect.value;
-    Array.from(anchorSelect.options).forEach(o => {
-      if (o.value.startsWith('foja-')) anchorSelect.removeChild(o);
-    });
+    anchorSelect.innerHTML = '';
     fojas.forEach((_, idx) => {
       const opt = document.createElement('option');
       opt.value = `foja-${idx + 1}`;
@@ -522,6 +519,8 @@ function updateSuspensionSuggestions() {
     });
     if ([...anchorSelect.options].some(o => o.value === current)) {
       anchorSelect.value = current;
+    } else if (fojas.length > 0) {
+      anchorSelect.value = 'foja-1';
     }
   }
 
@@ -530,21 +529,19 @@ function updateSuspensionSuggestions() {
   let anchorDate = startDate;
   if (anchorSelect) {
     const selVal = anchorSelect.value;
-    if (selVal === 'last') {
-      anchorDate = fojas.length ? fojas[fojas.length - 1].hasta : startDate;
-    } else if (selVal.startsWith('foja-')) {
+    if (selVal.startsWith('foja-')) {
       const n = parseInt(selVal.split('-')[1]);
       if (fojas[n - 1]) anchorDate = fojas[n - 1].desde;
     }
   }
 
   const nonWorkRanges = suspensions.concat(pauses);
-  const suggestion = endDateForWorkedDays(anchorDate, 29, nonWorkRanges);
+  const suggestion = endDateForWorkedDays(anchorDate, 30, nonWorkRanges);
 
   const targetGroup = groups[groups.length - 1];
   const p = targetGroup.querySelector('.suspensionSuggestion');
   if (suggestion) {
-    p.innerHTML = `Se sugiere suspender a partir del <span class="suggestion-date">${formatDate(suggestion)}</span>.`;
+    p.innerHTML = `Se le sugiere guardar 1 día de los 30 para medir después de la suspensión. Por lo tanto debería suspender a partir del <span class="suggestion-date">${formatDate(suggestion)}</span>.`;
     const rangeEl = targetGroup.querySelector('.suspensionRange');
     if (!rangeEl.value) {
       const iso = formatISO(suggestion);
@@ -553,21 +550,4 @@ function updateSuspensionSuggestions() {
   } else {
     p.textContent = 'Complete la fecha de inicio y el plazo inicial para obtener sugerencia.';
   }
-}
-
-function suggestSuspensionFromFoja(n) {
-  const hasSel = document.getElementById('hasSuspensions');
-  const wasNo = hasSel.value !== 'yes';
-  if (wasNo) {
-    hasSel.value = 'yes';
-    hasSel.dispatchEvent(new Event('change'));
-  } else {
-    const countInput = document.getElementById('suspensionCount');
-    countInput.value = (parseInt(countInput.value) || 0) + 1;
-    countInput.dispatchEvent(new Event('input'));
-  }
-  const anchorSelect = document.getElementById('suspensionAnchor');
-  anchorSelect.value = `foja-${n}`;
-  anchorSelect.dispatchEvent(new Event('change'));
-  updateSuspensionSuggestions();
 }


### PR DESCRIPTION
## Summary
- remove global suspension anchor and show foja selector only when suspensions are enabled
- recompute suggestions from selected foja start using working days
- restore foja table without extra action column

## Testing
- `node --check project.js`
- `node - <<'NODE'
const fs=require('fs'); const vm=require('vm');
const sandbox={window:{addEventListener:()=>{}},document:{getElementById:(id)=>({addEventListener:()=>{},value:'',innerHTML:'',style:{}}),querySelector:()=>null,querySelectorAll:()=>[],},console};
vm.runInNewContext(fs.readFileSync('project.js','utf8'), sandbox);
const {buildFojas,endDateForWorkedDays,formatDate}=sandbox;

function format(date){return formatDate(date);}

// Case A
const startA=new Date(2024,7,1); //01/08/2024
const fojasA=buildFojas(startA,60,[],[]);
const suggA=endDateForWorkedDays(fojasA[1].desde,30,[]);
console.log('Case A foja2 start:',format(fojasA[1].desde),'suggestion:',format(suggA));

// Case B: suspension 10/08-12/08
const suspB=[[new Date(2024,7,10),new Date(2024,7,12)]];
const fojasB=buildFojas(startA,60,suspB,[]);
const suggB=endDateForWorkedDays(fojasB[1].desde,30,suspB);
console.log('Case B foja2 start:',format(fojasB[1].desde),'suggestion:',format(suggB));

// Case C: pause 31/08-05/09
const pausesC=[[new Date(2024,7,31), new Date(2024,8,5)]];
const fojasC=buildFojas(startA,60,[],pausesC);
const suggC=endDateForWorkedDays(fojasC[1].desde,30,pausesC);
console.log('Case C foja2 start:',format(fojasC[1].desde),'suggestion:',format(suggC));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68ad1b863ad0832e86976e7fb7b8fb62