### PR TITLE
Highlight measurement day in calendar with yellow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -884,8 +884,8 @@ body.dark-mode img {
 }
 
 .measurement-day {
-  background: #28a745;
-  color: #fff;
+  background: #ffeb3b;
+  color: #000;
   border: 2px solid #f58b2a;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- Update calendar styles so measurement days display with a yellow background and black text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ade8cf736c832e85ca36b02d33c441