### PR TITLE
Add redeterminación assistant with login and clause generator

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,171 @@
+// Asistente de Redeterminación de Precios
+
+document.addEventListener('DOMContentLoaded', () => {
+  const openBtn = document.getElementById('abrirAsistente');
+  const modal = document.getElementById('loginModal');
+  const menu = document.getElementById('servicios');
+  const vista = document.getElementById('vistaAsistente');
+  const loginIng = document.getElementById('loginIngresar');
+  const loginCanc = document.getElementById('loginCancelar');
+  const salirBtn = document.getElementById('salirAsistente');
+  const genSaltosBtn = document.getElementById('generarSaltos');
+  const redactarBtn = document.getElementById('redactarClausula');
+  const limpiarBtn = document.getElementById('limpiarFormulario');
+
+  if (openBtn) {
+    openBtn.addEventListener('click', () => {
+      if (localStorage.getItem('certy_redet_auth') === '1') {
+        mostrarAsistente();
+      } else {
+        modal.classList.remove('oculto');
+      }
+    });
+  }
+
+  loginIng.addEventListener('click', () => {
+    const user = document.getElementById('loginUsuario').value.trim();
+    const pass = document.getElementById('loginClave').value;
+    const err = document.getElementById('loginError');
+    if (user === 'LUCERODAMI' && pass === 'RED2025') {
+      localStorage.setItem('certy_redet_auth', '1');
+      err.textContent = '';
+      modal.classList.add('oculto');
+      mostrarAsistente();
+    } else {
+      err.textContent = 'Usuario o contraseña incorrectos.';
+    }
+  });
+
+  loginCanc.addEventListener('click', () => {
+    modal.classList.add('oculto');
+  });
+
+  salirBtn.addEventListener('click', () => {
+    localStorage.removeItem('certy_redet_auth');
+    vista.classList.add('oculto');
+    menu.classList.remove('oculto');
+  });
+
+  genSaltosBtn.addEventListener('click', generarSaltos);
+  redactarBtn.addEventListener('click', redactarClausula);
+  limpiarBtn.addEventListener('click', limpiarFormulario);
+
+  if (localStorage.getItem('certy_redet_auth') === '1') {
+    mostrarAsistente();
+  }
+
+  function mostrarAsistente() {
+    menu.classList.add('oculto');
+    vista.classList.remove('oculto');
+  }
+});
+
+function generarSaltos() {
+  const cantidad = parseInt(document.getElementById('cantidadSaltos').value, 10);
+  const cont = document.getElementById('saltosContainer');
+  cont.innerHTML = '';
+  if (isNaN(cantidad) || cantidad < 1 || cantidad > 20) {
+    alert('Ingrese una cantidad válida de saltos (1-20).');
+    return;
+  }
+  for (let i = 0; i < cantidad; i++) {
+    const row = document.createElement('div');
+    row.className = 'salto-row';
+    row.innerHTML = `
+      <span>${ordinalesMasc[i]} Salto</span>
+      <input type="text" class="salto-acum" placeholder="NN,NN">
+      <input type="text" class="salto-fecha" placeholder="MM/AA">
+    `;
+    cont.appendChild(row);
+  }
+}
+
+function redactarClausula() {
+  const nRed = parseInt(document.getElementById('numeroRedet').value, 10);
+  if (isNaN(nRed) || nRed < 1) {
+    alert('Ingrese el número de redeterminación.');
+    return;
+  }
+  const saltosRows = document.querySelectorAll('#saltosContainer .salto-row');
+  if (saltosRows.length === 0) {
+    alert('Genere las filas de saltos.');
+    return;
+  }
+  const saltos = [];
+  for (const row of saltosRows) {
+    const acumStr = row.querySelector('.salto-acum').value.trim();
+    const fecha = row.querySelector('.salto-fecha').value.trim();
+    if (!acumStr || isNaN(parsePct(acumStr))) {
+      alert('Complete los porcentajes acumulados correctamente.');
+      return;
+    }
+    if (!/^\d{2}\/\d{2}$/.test(fecha)) {
+      alert('Complete las fechas de los saltos con formato MM/AA.');
+      return;
+    }
+    saltos.push({ acum: parsePct(acumStr), fecha });
+  }
+
+  let clausula = `TERCERA: Conforme la metodología aplicada, surge de la aplicación de los coeficientes detallados, la ${ordinalesFem[nRed-1] || nRed + 'ª'} Redeterminación atento a `;
+
+  saltos.forEach((s, idx) => {
+    const ord = ordinalesMasc[idx];
+    if (idx === 0) {
+      clausula += `un ${ord} Salto Inicial de ${toComma(s.acum)}% al ${s.fecha}`;
+    } else {
+      const prev = saltos[idx - 1].acum;
+      const delta = s.acum - prev;
+      const ref = idx === 1 ? 'Salto Anterior' : `${ordinalesMasc[idx - 1]} Salto`;
+      clausula += `, un ${ord} Salto de ${toComma(s.acum)}% (${toComma(delta)}% respecto del ${ref}) al ${s.fecha}`;
+    }
+  });
+
+  clausula += ',';
+
+  const monto = document.getElementById('montoDif').value.trim();
+  const montoLetras = document.getElementById('montoLetras').value.trim();
+  if (monto && montoLetras) {
+    clausula += ` generando esto una Diferencia de Precios para la Obra de $${monto} son (${montoLetras}).`;
+  }
+  const periodo = document.getElementById('periodoSaldo').value.trim();
+  if (periodo) {
+    const ult = saltos[saltos.length - 1];
+    const ordUlt = ordinalesMasc[saltos.length - 1];
+    clausula += ` El ${ordUlt} Salto de ${toComma(ult.acum)}% acumulado será de aplicación para el saldo de obra a partir del período ${periodo}.`;
+  }
+  document.getElementById('resultado').value = clausula;
+}
+
+function limpiarFormulario() {
+  document.getElementById('formAsistente').reset();
+  document.getElementById('saltosContainer').innerHTML = '';
+  document.getElementById('resultado').value = '';
+}
+
+function toComma(n) {
+  return n.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function parsePct(str) {
+  if (!str) return NaN;
+  return parseFloat(str.replace(/\./g, '').replace(',', '.'));
+}
+
+const ordinalesMasc = [
+  'Primer', 'Segundo', 'Tercer', 'Cuarto', 'Quinto', 'Sexto', 'Séptimo', 'Octavo', 'Noveno', 'Décimo',
+  'Undécimo', 'Duodécimo', 'Decimotercer', 'Decimocuarto', 'Decimoquinto', 'Decimosexto', 'Decimoséptimo', 'Decimoctavo', 'Decimonoveno', 'Vigésimo'
+];
+
+const ordinalesFem = [
+  'Primera', 'Segunda', 'Tercera', 'Cuarta', 'Quinta', 'Sexta', 'Séptima', 'Octava', 'Novena', 'Décima',
+  'Undécima', 'Duodécima', 'Decimotercera', 'Decimocuarta', 'Decimoquinta', 'Decimosexta', 'Decimoséptima', 'Decimoctava', 'Decimonovena', 'Vigésima'
+];
+
+function onEmpresaChange(nombre) {
+  // TODO: integrar con Google Sheets
+  fetchEmpresaPorNombre(nombre);
+}
+
+function fetchEmpresaPorNombre(nombre) {
+  // TODO: Implementar búsqueda de empresa en Sheets
+}

--- a/index.html
+++ b/index.html
@@ -57,6 +57,16 @@
           </a>
         </li>
         <li>
+          <div class="card-button">
+            <img src="Certy_mareado.png" alt="Asistente de Redeterminación" class="card-img" loading="lazy">
+            <div class="card-content">
+              <h3 class="card-title">Asistente de Redeterminación de Precios</h3>
+              <p class="card-subtitle">Generá Acta, Pase, Renuncia y Excel de Póliza.</p>
+              <button id="abrirAsistente" class="card-action">Abrir</button>
+            </div>
+          </div>
+        </li>
+        <li>
           <button class="card-button" aria-label="Próximamente más funciones" disabled>
             <img src="Certy_trabajando.png" alt="Certy trabajando" class="card-img" loading="lazy">
             <div class="card-content">
@@ -67,6 +77,94 @@
         </li>
       </ul>
     </nav>
+  </main>
+
+  <div id="loginModal" class="modal oculto" role="dialog" aria-modal="true">
+    <div class="modal-card">
+      <h3>Login</h3>
+      <label>Usuario
+        <input type="text" id="loginUsuario" autocomplete="username">
+      </label>
+      <label>Contraseña
+        <input type="password" id="loginClave" autocomplete="current-password">
+      </label>
+      <div id="loginError" class="login-error" aria-live="polite"></div>
+      <div class="modal-actions">
+        <button id="loginIngresar">Ingresar</button>
+        <button id="loginCancelar">Cancelar</button>
+      </div>
+    </div>
+  </div>
+
+  <main id="vistaAsistente" class="oculto">
+    <div class="asistente-header">
+      <h2>Asistente de Redeterminación de Precios</h2>
+      <button id="salirAsistente">Salir</button>
+    </div>
+    <form id="formAsistente" class="asistente-grid">
+      <fieldset>
+        <legend>Datos de la empresa</legend>
+        <label>Empresa
+          <input type="text" id="empresa" onchange="onEmpresaChange(this.value)">
+        </label>
+        <label>CUIT
+          <input type="text" id="cuit">
+        </label>
+        <label>Representación
+          <select id="representacion">
+            <option value="Presidente">Presidente</option>
+            <option value="Apoderado">Apoderado</option>
+            <option value="Gerente">Gerente</option>
+            <option value="Apoderado General">Apoderado General</option>
+          </select>
+        </label>
+        <label>Nombre representante
+          <input type="text" id="nombreRepresentante">
+        </label>
+        <label>DNI representante
+          <input type="text" id="dniRepresentante">
+        </label>
+        <label>Domicilio legal
+          <input type="text" id="domicilioLegal">
+        </label>
+        <label>Email
+          <input type="email" id="emailEmpresa">
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Redeterminación</legend>
+        <label>N° de Redeterminación
+          <input type="number" id="numeroRedet" min="1">
+        </label>
+        <label>Monto Diferencia de Precios ($)
+          <input type="text" id="montoDif">
+        </label>
+        <label>Monto en letras
+          <input type="text" id="montoLetras">
+        </label>
+        <label>Período de aplicación saldo de obra (MM/AAAA)
+          <input type="text" id="periodoSaldo" placeholder="MM/AAAA">
+        </label>
+      </fieldset>
+
+      <fieldset class="saltos">
+        <legend>Saltos FRI</legend>
+        <div class="saltos-config">
+          <label>Cantidad de saltos
+            <input type="number" id="cantidadSaltos" min="1" max="20">
+          </label>
+          <button type="button" id="generarSaltos">Generar filas</button>
+        </div>
+        <div id="saltosContainer"></div>
+      </fieldset>
+
+      <div class="acciones">
+        <button type="button" id="redactarClausula">Redactar Cláusula TERCERA</button>
+        <button type="reset" id="limpiarFormulario">Limpiar</button>
+      </div>
+      <textarea id="resultado" readonly></textarea>
+    </form>
   </main>
 
   <button id="downloadAppBtn" onclick="installApp()" aria-label="Descargar aplicación de Certy">
@@ -81,6 +179,7 @@
   </footer>
 
   <script src="common.js"></script>
+  <script src="app.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.4.9/mammoth.browser.min.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -1041,3 +1041,89 @@ body.dark-mode img {
   #reporte { max-width: none; }
   a { text-decoration: none; color: black; }
 }
+
+/* --- Asistente de Redeterminación --- */
+.oculto {
+  display: none !important;
+}
+
+.card-action {
+  margin-top: 8px;
+  padding: 8px 16px;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.modal-card {
+  background: var(--card-bg);
+  padding: 1.5rem;
+  border-radius: var(--card-radius);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 280px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.login-error {
+  color: red;
+  min-height: 1.2rem;
+}
+
+#vistaAsistente {
+  padding: 1rem;
+}
+
+.asistente-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.asistente-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.saltos-config {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.salto-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+#resultado {
+  width: 100%;
+  min-height: 150px;
+}


### PR DESCRIPTION
## Summary
- add Asistente de Redeterminación menu block with login modal and protected view
- implement clause generator for saltos FRI with dynamic rows and formatting utilities
- style modal and assistant grid layout

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c6f6badc8c832ea168efdd65cd0aa4