### PR TITLE
Remove login requirement from redeterminaciones

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,40 +1,10 @@
 // Lógica del Asistente de Redeterminación de Precios
 
 document.addEventListener('DOMContentLoaded', () => {
-  const modal = document.getElementById('loginModal');
-  if (modal && localStorage.getItem('certy_redet_auth') !== '1') {
-    modal.classList.remove('oculto');
-  }
-
-  const loginIng = document.getElementById('loginIngresar');
-  if (loginIng) {
-    loginIng.addEventListener('click', () => {
-      const user = document.getElementById('loginUsuario');
-      const pass = document.getElementById('loginClave');
-      const err = document.getElementById('loginError');
-      if (user && pass && err) {
-        if (user.value.trim() === 'LUCERODAMI' && pass.value === 'RED2025') {
-          localStorage.setItem('certy_redet_auth', '1');
-          err.textContent = '';
-          if (modal) modal.classList.add('oculto');
-        } else {
-          err.textContent = 'Usuario o contraseña incorrectos.';
-        }
-      }
-    });
-  }
-
-  const loginCanc = document.getElementById('loginCancelar');
-  if (loginCanc) {
-    loginCanc.addEventListener('click', () => {
-      window.location.href = 'index.html';
-    });
-  }
 
   const salirBtn = document.getElementById('salirAsistente');
   if (salirBtn) {
     salirBtn.addEventListener('click', () => {
-      localStorage.removeItem('certy_redet_auth');
       window.location.href = 'index.html';
     });
   }

--- a/redeterminaciones.html
+++ b/redeterminaciones.html
@@ -139,22 +139,6 @@
     </div>
   </div>
 
-  <div id="loginModal" class="modal oculto" role="dialog" aria-modal="true">
-    <div class="modal-card">
-      <h3>Login</h3>
-      <label>Usuario
-        <input type="text" id="loginUsuario" autocomplete="username">
-      </label>
-      <label>Contraseña
-        <input type="password" id="loginClave" autocomplete="current-password">
-      </label>
-      <div id="loginError" class="login-error" aria-live="polite"></div>
-      <div class="modal-actions">
-        <button id="loginIngresar">Ingresar</button>
-        <button id="loginCancelar">Cancelar</button>
-      </div>
-    </div>
-  </div>
 
   <script src="common.js"></script>
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- Drop login modal from redeterminaciones.html so the assistant loads without authentication
- Simplify app.js by removing user/password check and localStorage usage

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68c7307b8f48832eb7fbb4d6ae352cff