### PR TITLE
Update redeterminaciones form with auto-filled company data

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,13 +5,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const formContainer = document.querySelector('.form-container');
   if (formContainer) formContainer.classList.add('loaded');
 
-  const salirBtn = document.getElementById('salirAsistente');
-  if (salirBtn) {
-    salirBtn.addEventListener('click', () => {
-      window.location.href = 'index.html';
-    });
-  }
-
   const genSaltosBtn = document.getElementById('generarSaltos');
   if (genSaltosBtn) genSaltosBtn.addEventListener('click', generarSaltos);
 
@@ -19,7 +12,10 @@ document.addEventListener('DOMContentLoaded', () => {
   if (limpiarBtn) limpiarBtn.addEventListener('click', limpiarFormulario);
 
   const empresaSel = document.getElementById('empresa');
-  if (empresaSel) empresaSel.addEventListener('change', e => toggleEmpresaOtro(e.target.value));
+  if (empresaSel) {
+    cargarDatosEmpresas().catch(err => console.error('Error al precargar empresas', err));
+    empresaSel.addEventListener('change', e => manejarCambioEmpresa(e.target.value));
+  }
 
   const polizaSel = document.getElementById('tienePoliza');
   if (polizaSel) polizaSel.addEventListener('change', e => togglePoliza(e.target.value));
@@ -54,6 +50,7 @@ function limpiarFormulario() {
   if (cont) cont.innerHTML = '';
   const empresa = document.getElementById('empresa');
   if (empresa) toggleEmpresaOtro(empresa.value);
+  limpiarCamposEmpresa();
   const poliza = document.getElementById('tienePoliza');
   if (poliza) togglePoliza(poliza.value);
 }
@@ -76,3 +73,83 @@ const ordinalesMasc = [
   'Primer', 'Segundo', 'Tercer', 'Cuarto', 'Quinto', 'Sexto', 'Séptimo', 'Octavo', 'Noveno', 'Décimo',
   'Undécimo', 'Duodécimo', 'Decimotercer', 'Decimocuarto', 'Decimoquinto', 'Decimosexto', 'Decimoséptimo', 'Decimooctavo', 'Decimonoveno', 'Vigésimo'
 ];
+
+let empresasCache = null;
+let empresasPromise = null;
+
+async function cargarDatosEmpresas() {
+  if (empresasCache) return empresasCache;
+  if (!empresasPromise) {
+    const sheetId = '10qtk3KQplhuMqVDXjl61vZH8J-ELUN-fRnst1srLYfI';
+    const query = 'select A,B,C,D';
+    const url = `https://docs.google.com/spreadsheets/d/${sheetId}/gviz/tq?tqx=out:json&sheet=Empresas&tq=${encodeURIComponent(query)}`;
+    empresasPromise = fetch(url)
+      .then(res => res.text())
+      .then(text => {
+        const json = JSON.parse(text.substring(text.indexOf('{'), text.lastIndexOf('}') + 1));
+        const data = {};
+        if (json.table && Array.isArray(json.table.rows)) {
+          json.table.rows.forEach(row => {
+            if (!row || !Array.isArray(row.c)) return;
+            const cells = row.c;
+            const empresa = cells[0] && cells[0].v ? String(cells[0].v).trim() : '';
+            if (!empresa) return;
+            const key = normalizarEmpresa(empresa);
+            if (!key) return;
+            data[key] = {
+              tipo: cells[1] && cells[1].v ? String(cells[1].v).trim() : '',
+              nombreDni: cells[2] && cells[2].v ? String(cells[2].v).trim() : '',
+              domicilio: cells[3] && cells[3].v ? String(cells[3].v).trim() : ''
+            };
+          });
+        }
+        empresasCache = data;
+        return data;
+      });
+  }
+  return empresasPromise;
+}
+
+function manejarCambioEmpresa(valor) {
+  toggleEmpresaOtro(valor);
+  if (!valor || valor === 'OTRO') {
+    limpiarCamposEmpresa();
+    return;
+  }
+  cargarDatosEmpresas()
+    .then(data => {
+      const info = data[normalizarEmpresa(valor)];
+      if (info) {
+        const tipo = document.getElementById('repTipo');
+        const nombreDni = document.getElementById('repNombreDni');
+        const domicilio = document.getElementById('repDomicilio');
+        if (tipo) tipo.value = info.tipo || '';
+        if (nombreDni) nombreDni.value = info.nombreDni || '';
+        if (domicilio) domicilio.value = info.domicilio || '';
+      } else {
+        limpiarCamposEmpresa();
+      }
+    })
+    .catch(err => {
+      console.error('Error al cargar datos de la empresa', err);
+      limpiarCamposEmpresa();
+    });
+}
+
+function limpiarCamposEmpresa() {
+  const tipo = document.getElementById('repTipo');
+  const nombreDni = document.getElementById('repNombreDni');
+  const domicilio = document.getElementById('repDomicilio');
+  if (tipo) tipo.value = '';
+  if (nombreDni) nombreDni.value = '';
+  if (domicilio) domicilio.value = '';
+}
+
+function normalizarEmpresa(nombre) {
+  if (!nombre) return '';
+  return String(nombre)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toLowerCase();
+}

--- a/redeterminaciones.html
+++ b/redeterminaciones.html
@@ -32,7 +32,6 @@
     <div class="container form-container">
       <div class="asistente-header">
         <h1>Asistente de Redeterminación de Precios</h1>
-        <button id="salirAsistente">Salir</button>
       </div>
       <form id="formAsistente" class="asistente-grid">
         <fieldset>
@@ -82,24 +81,18 @@
           <label id="empresaOtroLabel" class="oculto">Otra empresa
             <input type="text" id="empresaOtro">
           </label>
-          <label>CUIT
-            <input type="text" id="CUIT">
-          </label>
         </fieldset>
 
         <fieldset>
           <legend>Representante</legend>
           <label>Tipo
-            <select id="repTipo">
-              <option>Administrador</option>
-              <option>Apoderado</option>
-            </select>
+            <input type="text" id="repTipo">
           </label>
-          <label>Nombre
-            <input type="text" id="repNombre">
+          <label>Nombre y DNI
+            <input type="text" id="repNombreDni">
           </label>
-          <label>DNI
-            <input type="text" id="repDNI">
+          <label>Domicilio
+            <input type="text" id="repDomicilio">
           </label>
         </fieldset>
 


### PR DESCRIPTION
## Summary
- remove the redundant salir button and CUIT field from the redeterminaciones assistant
- combine representative name and DNI fields, add domicile, and wire them for auto-fill
- load company details from the provided Google Sheet when a company is selected

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d011cd3380832e86a48bf7f5b1eda4