### PR TITLE
Agregar bloque de datos de la obra en redeterminaciones

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const polizaSel = document.getElementById('tienePoliza');
   if (polizaSel) polizaSel.addEventListener('change', e => togglePoliza(e.target.value));
+
+  const aprobadaPorSel = document.getElementById('aprobadaPor');
+  if (aprobadaPorSel) {
+    aprobadaPorSel.addEventListener('change', e => actualizarAprobadaPor(e.target.value));
+    actualizarAprobadaPor(aprobadaPorSel.value);
+  }
+
+  const buscarBtn = document.getElementById('buscarResolucion');
+  if (buscarBtn) buscarBtn.addEventListener('click', abrirDigestoResolucion);
 });
 
 function generarSaltos() {
@@ -53,6 +62,8 @@ function limpiarFormulario() {
   limpiarCamposEmpresa();
   const poliza = document.getElementById('tienePoliza');
   if (poliza) togglePoliza(poliza.value);
+  const aprobadaPor = document.getElementById('aprobadaPor');
+  if (aprobadaPor) actualizarAprobadaPor(aprobadaPor.value);
 }
 
 function toggleEmpresaOtro(val) {
@@ -152,4 +163,37 @@ function normalizarEmpresa(nombre) {
     .replace(/[\u0300-\u036f]/g, '')
     .replace(/[^a-zA-Z0-9]/g, '')
     .toLowerCase();
+}
+
+function actualizarAprobadaPor(valor) {
+  const hint = document.getElementById('aprobadaPorHint');
+  const btn = document.getElementById('buscarResolucion');
+  if (hint) hint.textContent = '';
+  if (!btn) return;
+  if (valor === 'resolucion') {
+    if (hint) hint.textContent = 'Buscar la fecha en la página de Digesto';
+    btn.classList.remove('oculto');
+  } else if (valor === 'disposicion') {
+    if (hint) hint.textContent = 'Consultarle a la subsecretaría';
+    btn.classList.add('oculto');
+  } else {
+    btn.classList.add('oculto');
+  }
+}
+
+function abrirDigestoResolucion() {
+  const tipo = document.getElementById('aprobadaPor');
+  if (!tipo || tipo.value !== 'resolucion') return;
+  const numeroInput = document.getElementById('aprobadaNumero');
+  if (!numeroInput) return;
+  const valor = (numeroInput.value || '').trim();
+  const match = valor.match(/^(\d{4})\/(\d{2})$/);
+  if (!match) {
+    alert('Ingrese un número válido con el formato nnnn/aa.');
+    return;
+  }
+  const [, numero, anioCorto] = match;
+  const url = `https://www.muninqn.gov.ar/info/doc/digesto/RESOLUCIONES/20${anioCorto}/r-${numero}-${anioCorto}-.pdf`;
+  const nuevaVentana = window.open(url, '_blank');
+  if (nuevaVentana) nuevaVentana.opener = null;
 }

--- a/redeterminaciones.html
+++ b/redeterminaciones.html
@@ -97,6 +97,33 @@
         </fieldset>
 
         <fieldset>
+          <legend>Datos de la obra</legend>
+          <label>Nombre de la obra
+            <input type="text" id="obraNombre">
+          </label>
+          <small class="field-hint"><em>Sugerencia: copiar y pegar el nombre del sistema GESOP.</em></small>
+          <div class="aprobada-por-row">
+            <div class="aprobada-por-field">
+              <label>Aprobada por
+                <select id="aprobadaPor">
+                  <option value="" disabled selected>Seleccione</option>
+                  <option value="resolucion">Resolución de Adjudicación</option>
+                  <option value="disposicion">Disposición de Adjudicación</option>
+                </select>
+              </label>
+              <small class="field-hint"><em id="aprobadaPorHint"></em></small>
+            </div>
+            <label>Número
+              <input type="text" id="aprobadaNumero" placeholder="nnnn/aa" pattern="\d{4}/\d{2}" maxlength="7" inputmode="numeric">
+            </label>
+            <label>Fecha
+              <input type="text" id="aprobadaFecha" placeholder="dd/mm/aaaa" pattern="\d{2}/\d{2}/\d{4}">
+            </label>
+            <button type="button" id="buscarResolucion" class="buscar-digesto oculto">BUSCAR</button>
+          </div>
+        </fieldset>
+
+        <fieldset>
           <legend>Redeterminación</legend>
           <label>N° de Redeterminación
             <input type="number" id="nRedet" min="1">

--- a/styles.css
+++ b/styles.css
@@ -564,6 +564,46 @@ label {
   margin-top: 1rem;
 }
 
+.field-hint {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: #555;
+}
+
+.aprobada-por-row {
+  display: grid;
+  gap: 0.75rem;
+  align-items: end;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin-top: 1rem;
+}
+
+.aprobada-por-row label {
+  margin-top: 0;
+}
+
+.aprobada-por-field {
+  display: flex;
+  flex-direction: column;
+}
+
+.buscar-digesto {
+  align-self: end;
+  padding: 0.6rem 1rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.3s, transform 0.2s;
+}
+
+.buscar-digesto:hover {
+  background: var(--color-secondary);
+  transform: translateY(-1px);
+}
+
 input,
 select {
   width: 100%;


### PR DESCRIPTION
## Summary
- agregar un nuevo bloque de "Datos de la obra" en el asistente de redeterminaciones con campos de nombre, acto de aprobación, número y fecha
- mostrar sugerencias contextuales y habilitar un acceso rápido al Digesto cuando se selecciona una resolución de adjudicación
- incorporar estilos y lógica JavaScript para gestionar los nuevos campos y el botón de búsqueda

## Testing
- not run (no tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68d019d7dbf4832e966aa6c92c3e981d