### PR TITLE
Implement fallback URL for resolucion search

### DIFF
--- a/app.js
+++ b/app.js
@@ -181,7 +181,7 @@ function actualizarAprobadaPor(valor) {
   }
 }
 
-function abrirDigestoResolucion() {
+async function abrirDigestoResolucion() {
   const tipo = document.getElementById('aprobadaPor');
   if (!tipo || tipo.value !== 'resolucion') return;
   const numeroInput = document.getElementById('aprobadaNumero');
@@ -193,7 +193,32 @@ function abrirDigestoResolucion() {
     return;
   }
   const [, numero, anioCorto] = match;
-  const url = `https://www.muninqn.gov.ar/info/doc/digesto/RESOLUCIONES/20${anioCorto}/r-${numero}-${anioCorto}-.pdf`;
-  const nuevaVentana = window.open(url, '_blank');
-  if (nuevaVentana) nuevaVentana.opener = null;
+  const base = `https://www.muninqn.gov.ar/info/doc/digesto/RESOLUCIONES/20${anioCorto}/r-${numero}-${anioCorto}`;
+  const urlConGuionFinal = `${base}-.pdf`;
+  const urlSinGuionFinal = `${base}.pdf`;
+
+  const abrirEnNuevaPestana = url => {
+    const nuevaVentana = window.open(url, '_blank');
+    if (nuevaVentana) nuevaVentana.opener = null;
+  };
+
+  try {
+    const respuesta = await fetch(urlConGuionFinal, { method: 'HEAD' });
+    if (respuesta.ok) {
+      abrirEnNuevaPestana(urlConGuionFinal);
+      return;
+    }
+    if (respuesta.status === 404) {
+      const alternativa = await fetch(urlSinGuionFinal, { method: 'HEAD' });
+      if (alternativa.ok) {
+        abrirEnNuevaPestana(urlSinGuionFinal);
+        return;
+      }
+    }
+  } catch (error) {
+    console.warn('No se pudo verificar la resolución con guion final. Intentando alternativa.', error);
+  }
+
+  // Si no se pudo confirmar la existencia de las URLs anteriores, abrir la alternativa sin guion.
+  abrirEnNuevaPestana(urlSinGuionFinal);
 }


### PR DESCRIPTION
## Summary
- Add asynchronous digesto lookup that verifica la existencia del PDF de resolución
- Intenta abrir el PDF con guion final y, ante un 404, prueba la variante sin guion
- Abre siempre la mejor alternativa encontrada en una nueva pestaña

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d01e3ed8b0832e9c774b06db85acdd