### PR TITLE
Agrega campos y cálculo de montos en redeterminaciones

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const buscarBtn = document.getElementById('buscarResolucion');
   if (buscarBtn) buscarBtn.addEventListener('click', abrirDigestoResolucion);
+
+  inicializarMontoRedeterminacion();
 });
 
 function generarSaltos() {
@@ -43,8 +45,9 @@ function generarSaltos() {
   for (let i = 0; i < cantidad; i++) {
     const row = document.createElement('div');
     row.className = 'salto-row';
+    const etiqueta = i === 0 ? 'Salto inicial' : `${ordinalesMasc[i]} Salto`;
     row.innerHTML = `
-      <span>${ordinalesMasc[i]} Salto</span>
+      <span>${etiqueta}</span>
       <input type="text" class="salto-acum" placeholder="NN,NN">
       <input type="text" class="salto-fecha" placeholder="MM/AA">
     `;
@@ -64,6 +67,8 @@ function limpiarFormulario() {
   if (poliza) togglePoliza(poliza.value);
   const aprobadaPor = document.getElementById('aprobadaPor');
   if (aprobadaPor) actualizarAprobadaPor(aprobadaPor.value);
+  const montoLetras = document.getElementById('montoRedeterminacionLetras');
+  if (montoLetras) montoLetras.value = '';
 }
 
 function toggleEmpresaOtro(val) {
@@ -84,6 +89,144 @@ const ordinalesMasc = [
   'Primer', 'Segundo', 'Tercer', 'Cuarto', 'Quinto', 'Sexto', 'Séptimo', 'Octavo', 'Noveno', 'Décimo',
   'Undécimo', 'Duodécimo', 'Decimotercer', 'Decimocuarto', 'Decimoquinto', 'Decimosexto', 'Decimoséptimo', 'Decimooctavo', 'Decimonoveno', 'Vigésimo'
 ];
+
+function inicializarMontoRedeterminacion() {
+  const montoInput = document.getElementById('montoRedeterminacion');
+  const montoLetras = document.getElementById('montoRedeterminacionLetras');
+  const form = document.getElementById('formAsistente');
+  if (!montoInput || !montoLetras) return;
+
+  const actualizarMonto = () => {
+    const crudo = (montoInput.value || '').trim();
+    if (!crudo) {
+      montoLetras.value = '';
+      return;
+    }
+    const normalizado = normalizarMontoTexto(crudo);
+    const numero = Number(normalizado);
+    if (Number.isNaN(numero)) {
+      montoLetras.value = '';
+      return;
+    }
+    const valor = Math.round(numero * 100) / 100;
+    montoLetras.value = numeroALetras(valor);
+  };
+
+  montoInput.addEventListener('input', actualizarMonto);
+  montoInput.addEventListener('blur', actualizarMonto);
+  if (form) {
+    form.addEventListener('reset', () => {
+      setTimeout(() => {
+        montoLetras.value = '';
+      }, 0);
+    });
+  }
+  actualizarMonto();
+}
+
+function normalizarMontoTexto(valor) {
+  const limpio = valor.replace(/\s+/g, '');
+  const tieneComa = limpio.includes(',');
+  const tienePunto = limpio.includes('.');
+  if (tieneComa && tienePunto) {
+    return limpio.replace(/\./g, '').replace(',', '.');
+  }
+  if (tieneComa) return limpio.replace(',', '.');
+  if (tienePunto) {
+    const puntos = limpio.match(/\./g) || [];
+    if (puntos.length > 1) return limpio.replace(/\./g, '');
+  }
+  return limpio;
+}
+
+function numeroALetras(valor) {
+  if (typeof valor !== 'number' || !Number.isFinite(valor)) return '';
+  const absoluto = Math.abs(valor);
+  const entero = Math.floor(absoluto);
+  const decimales = Math.round((absoluto - entero) * 100);
+  const textoEntero = capitalizarCadaPalabra(convertirNumeroEntero(entero));
+  const textoDecimal = String(decimales).padStart(2, '0');
+  return `${textoEntero} con ${textoDecimal}/100`;
+}
+
+function convertirNumeroEntero(num) {
+  if (num === 0) return 'cero';
+  if (num < 1000) return convertirCentenas(num);
+  if (num < 1000000) {
+    const miles = Math.floor(num / 1000);
+    const resto = num % 1000;
+    const textoMiles = miles === 1 ? 'mil' : `${ajustarUn(convertirNumeroEntero(miles))} mil`;
+    const textoResto = resto ? convertirCentenas(resto) : '';
+    return textoResto ? `${textoMiles} ${textoResto}` : textoMiles;
+  }
+  if (num < 1000000000) {
+    const millones = Math.floor(num / 1000000);
+    const resto = num % 1000000;
+    const textoMillones = millones === 1 ? 'un millón' : `${ajustarUn(convertirNumeroEntero(millones))} millones`;
+    const textoResto = resto ? convertirNumeroEntero(resto) : '';
+    return textoResto ? `${textoMillones} ${textoResto}` : textoMillones;
+  }
+  const milesDeMillones = Math.floor(num / 1000000000);
+  const resto = num % 1000000000;
+  const textoMilesMillones = milesDeMillones === 1 ? 'mil millones' : `${ajustarUn(convertirNumeroEntero(milesDeMillones))} mil millones`;
+  const textoResto = resto ? convertirNumeroEntero(resto) : '';
+  return textoResto ? `${textoMilesMillones} ${textoResto}` : textoMilesMillones;
+}
+
+function convertirCentenas(num) {
+  if (num === 0) return '';
+  if (num === 100) return 'cien';
+  const centenas = Math.floor(num / 100);
+  const resto = num % 100;
+  const textoCentena = CENTENAS[centenas];
+  const textoResto = convertirDecenas(resto);
+  if (!textoCentena) return textoResto;
+  return textoResto ? `${textoCentena} ${textoResto}` : textoCentena;
+}
+
+function convertirDecenas(num) {
+  if (num === 0) return '';
+  if (num < 10) return UNIDADES[num];
+  if (num < 20) return DIEZ_A_DIECINUEVE[num - 10];
+  if (num === 20) return 'veinte';
+  if (num < 30) return VEINTI[num];
+  const decena = Math.floor(num / 10);
+  const unidad = num % 10;
+  const textoDecena = DECENAS[decena];
+  if (unidad === 0) return textoDecena;
+  return `${textoDecena} y ${UNIDADES[unidad]}`;
+}
+
+function ajustarUn(texto) {
+  return texto
+    .replace(/uno$/, 'un')
+    .replace(/veintiuno$/, 'veintiún')
+    .replace(/y uno$/, 'y un');
+}
+
+function capitalizarCadaPalabra(texto) {
+  return texto
+    .split(' ')
+    .filter(Boolean)
+    .map(palabra => palabra.charAt(0).toUpperCase() + palabra.slice(1))
+    .join(' ');
+}
+
+const UNIDADES = ['', 'uno', 'dos', 'tres', 'cuatro', 'cinco', 'seis', 'siete', 'ocho', 'nueve'];
+const DIEZ_A_DIECINUEVE = ['diez', 'once', 'doce', 'trece', 'catorce', 'quince', 'dieciséis', 'diecisiete', 'dieciocho', 'diecinueve'];
+const DECENAS = ['', '', 'veinte', 'treinta', 'cuarenta', 'cincuenta', 'sesenta', 'setenta', 'ochenta', 'noventa'];
+const CENTENAS = ['', 'ciento', 'doscientos', 'trescientos', 'cuatrocientos', 'quinientos', 'seiscientos', 'setecientos', 'ochocientos', 'novecientos'];
+const VEINTI = {
+  21: 'veintiuno',
+  22: 'veintidós',
+  23: 'veintitrés',
+  24: 'veinticuatro',
+  25: 'veinticinco',
+  26: 'veintiséis',
+  27: 'veintisiete',
+  28: 'veintiocho',
+  29: 'veintinueve'
+};
 
 let empresasCache = null;
 let empresasPromise = null;

--- a/redeterminaciones.html
+++ b/redeterminaciones.html
@@ -128,6 +128,26 @@
           <label>N° de Redeterminación
             <input type="number" id="nRedet" min="1">
           </label>
+          <small class="field-hint"><em>Sugerencia: Primera Redeterminación, Segunda Redeterminación.</em></small>
+          <label>Cambios registrados desde
+            <input type="text" id="cambiosDesde" placeholder="dd/mm/aaaa" pattern="\d{2}/\d{2}/\d{4}">
+          </label>
+          <small class="field-hint">Si es Licitación Pública, Licitación Privada o Concurso de Precios, la fecha es del Acta de Apertura del sobre A. Si es Contratación Directa, la fecha es de la Carta de Invitación.</small>
+          <label>Hasta
+            <input type="text" id="cambiosHasta" placeholder="mm/aaaa" pattern="\d{2}/\d{4}">
+          </label>
+          <label>Monto de la redeterminación
+            <div class="monto-input">
+              <span class="peso-signo" aria-hidden="true">$</span>
+              <input type="text" id="montoRedeterminacion" inputmode="decimal" pattern="\d+(?:[.,]\d{1,2})?" placeholder="0000000,00">
+            </div>
+            <small class="field-hint">Ingrese el monto sin separadores de miles.</small>
+          </label>
+          <div class="monto-letras-wrapper">
+            <label>Monto en letras
+              <input type="text" id="montoRedeterminacionLetras" class="monto-letras" readonly aria-readonly="true" placeholder="Se completará automáticamente">
+            </label>
+          </div>
         </fieldset>
 
         <fieldset class="saltos">

--- a/styles.css
+++ b/styles.css
@@ -571,6 +571,41 @@ label {
   color: #555;
 }
 
+.monto-input {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.monto-input input {
+  flex: 1;
+}
+
+.peso-signo {
+  font-weight: 600;
+  color: var(--color-primary);
+  font-size: 1.1rem;
+}
+
+.monto-letras-wrapper label {
+  margin-top: 0.5rem;
+}
+
+.monto-letras {
+  width: 100%;
+  background: #d6ebff;
+  border: 1px solid #99c6ff;
+  border-radius: 6px;
+  padding: 0.6rem;
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.monto-letras::placeholder {
+  color: #4d6fa6;
+}
+
 .aprobada-por-row {
   display: grid;
   gap: 0.75rem;


### PR DESCRIPTION
## Summary
- agrega campos de fechas y monto en la sección de redeterminación con las sugerencias solicitadas
- aplica estilos para los nuevos campos monetarios y el área de monto en letras
- renombra el primer salto a "Salto inicial" y convierte el monto numérico a letras automáticamente

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d027e777bc832eb1df3433be166d68