### PR TITLE
Adjust redeterminación form ordering and FRI saltos display

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,10 @@ function generarSaltos() {
     const etiqueta = i === 0 ? 'Salto inicial' : `${ordinalesMasc[i]} Salto`;
     row.innerHTML = `
       <span>${etiqueta}</span>
-      <input type="text" class="salto-acum" placeholder="NN,NN">
+      <div class="salto-porcentaje">
+        <input type="text" class="salto-acum" placeholder="NN,NN" inputmode="decimal" pattern="\\d+(?:[.,]\\d{1,2})?">
+        <span class="porcentaje-signo" aria-hidden="true">%</span>
+      </div>
       <input type="text" class="salto-fecha" placeholder="MM/AA">
     `;
     cont.appendChild(row);

--- a/redeterminaciones.html
+++ b/redeterminaciones.html
@@ -125,10 +125,6 @@
 
         <fieldset>
           <legend>Redeterminación</legend>
-          <label>N° de Redeterminación
-            <input type="number" id="nRedet" min="1">
-          </label>
-          <small class="field-hint"><em>Sugerencia: Primera Redeterminación, Segunda Redeterminación.</em></small>
           <label>Cambios registrados desde
             <input type="text" id="cambiosDesde" placeholder="dd/mm/aaaa" pattern="\d{2}/\d{2}/\d{4}">
           </label>
@@ -136,6 +132,44 @@
           <label>Hasta
             <input type="text" id="cambiosHasta" placeholder="mm/aaaa" pattern="\d{2}/\d{4}">
           </label>
+          <label>N° de Redeterminación
+            <select id="nRedet">
+              <option value="" disabled selected>Seleccione</option>
+              <option value="1">Primera Redeterminación</option>
+              <option value="2">Segunda Redeterminación</option>
+              <option value="3">Tercera Redeterminación</option>
+              <option value="4">Cuarta Redeterminación</option>
+              <option value="5">Quinta Redeterminación</option>
+              <option value="6">Sexta Redeterminación</option>
+              <option value="7">Séptima Redeterminación</option>
+              <option value="8">Octava Redeterminación</option>
+              <option value="9">Novena Redeterminación</option>
+              <option value="10">Décima Redeterminación</option>
+              <option value="11">Undécima Redeterminación</option>
+              <option value="12">Duodécima Redeterminación</option>
+              <option value="13">Decimotercera Redeterminación</option>
+              <option value="14">Decimocuarta Redeterminación</option>
+              <option value="15">Decimoquinta Redeterminación</option>
+              <option value="16">Decimosexta Redeterminación</option>
+              <option value="17">Decimoséptima Redeterminación</option>
+              <option value="18">Decimoctava Redeterminación</option>
+              <option value="19">Decimonovena Redeterminación</option>
+              <option value="20">Vigésima Redeterminación</option>
+            </select>
+          </label>
+          <small class="field-hint"><em>Sugerencia: Primera Redeterminación, Segunda Redeterminación.</em></small>
+          <div class="saltos-bloque">
+            <div class="saltos-encabezado">
+              <span class="saltos-titulo">Saltos FRI</span>
+              <div class="saltos-config">
+                <label>Cantidad de saltos
+                  <input type="number" id="cantidadSaltos" min="1" max="20">
+                </label>
+                <button type="button" id="generarSaltos">Generar filas</button>
+              </div>
+            </div>
+            <div id="saltosContainer" class="saltos-container"></div>
+          </div>
           <label>Monto de la redeterminación
             <div class="monto-input">
               <span class="peso-signo" aria-hidden="true">$</span>
@@ -148,17 +182,6 @@
               <input type="text" id="montoRedeterminacionLetras" class="monto-letras" readonly aria-readonly="true" placeholder="Se completará automáticamente">
             </label>
           </div>
-        </fieldset>
-
-        <fieldset class="saltos">
-          <legend>Saltos FRI</legend>
-          <div class="saltos-config">
-            <label>Cantidad de saltos
-              <input type="number" id="cantidadSaltos" min="1" max="20">
-            </label>
-            <button type="button" id="generarSaltos">Generar filas</button>
-          </div>
-          <div id="saltosContainer"></div>
         </fieldset>
 
         <fieldset>

--- a/styles.css
+++ b/styles.css
@@ -1184,11 +1184,33 @@ body.dark-mode img {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
+.saltos-bloque {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.saltos-encabezado {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.saltos-titulo {
+  font-weight: 600;
+}
+
 .saltos-config {
   display: flex;
   align-items: center;
   gap: 1rem;
-  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.saltos-container {
+  display: flex;
+  flex-direction: column;
 }
 
 .salto-row {
@@ -1196,4 +1218,19 @@ body.dark-mode img {
   grid-template-columns: 1fr 1fr 1fr;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
+}
+
+.salto-porcentaje {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.salto-porcentaje .salto-acum {
+  flex: 1;
+}
+
+.porcentaje-signo {
+  font-weight: 600;
+  color: var(--color-primary);
 }


### PR DESCRIPTION
## Summary
- reorder the redeterminación fieldset so the date inputs precede the ordinal selector
- replace the numeric redeterminación input with an ordinal dropdown and embed the FRI saltos controls in the same section
- append a visible percent symbol to each salto entry and refresh supporting styles for the new layout

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d9e7327d64832e8d3ad47950cfc226