### PR TITLE
Add policy calculator fields to redeterminaciones assistant

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const buscarBtn = document.getElementById('buscarResolucion');
   if (buscarBtn) buscarBtn.addEventListener('click', abrirDigestoResolucion);
 
+  inicializarPoliza();
   inicializarMontoRedeterminacion();
 });
 
@@ -56,6 +57,7 @@ function generarSaltos() {
     `;
     cont.appendChild(row);
   }
+  actualizarCalculosPoliza();
 }
 
 function limpiarFormulario() {
@@ -72,6 +74,7 @@ function limpiarFormulario() {
   if (aprobadaPor) actualizarAprobadaPor(aprobadaPor.value);
   const montoLetras = document.getElementById('montoRedeterminacionLetras');
   if (montoLetras) montoLetras.value = '';
+  actualizarCalculosPoliza();
 }
 
 function toggleEmpresaOtro(val) {
@@ -86,6 +89,254 @@ function togglePoliza(val) {
   if (!form) return;
   if (val === 'si') form.classList.remove('oculto');
   else form.classList.add('oculto');
+  actualizarCalculosPoliza();
+}
+
+function inicializarPoliza() {
+  const form = document.getElementById('formAsistente');
+  const poliza = document.getElementById('polizaForm');
+  if (!form || !poliza) return;
+
+  polizaContext = {
+    form,
+    hastaInput: document.getElementById('cambiosHasta'),
+    montoContrato: document.getElementById('polizaMontoContrato'),
+    montoConAdicionales: document.getElementById('polizaMontoConAdicionales'),
+    montoAcumulado: document.getElementById('polizaMontoObraAcumulada'),
+    saldoAnticipo: document.getElementById('polizaSaldoAnticipo'),
+    saldoNeto: document.getElementById('polizaSaldoNeto'),
+    ultimoFriValor: document.getElementById('polizaUltimoFriValor'),
+    ultimoFriAprobadoFecha: document.getElementById('polizaUltimoFriAprobadoFecha'),
+    ultimoFriAprobadoValor: document.getElementById('polizaUltimoFriAprobadoValor'),
+    incrementoFri: document.getElementById('polizaIncrementoFri'),
+    baseContratacion: document.getElementById('polizaBaseContratacion'),
+    baseContratacionCopia: document.getElementById('polizaBaseContratacionCopia'),
+    montoGarantizarSaldo: document.getElementById('polizaMontoGarantizarSaldoObra'),
+    certificadoRp: document.getElementById('polizaCertificadoRp'),
+    montoGarantizarRp: document.getElementById('polizaMontoGarantizarRp'),
+    montoTotal: document.getElementById('polizaMontoTotalGarantizar'),
+    montoClausula: document.getElementById('polizaMontoClausula'),
+    montoClausulaLetras: document.getElementById('polizaMontoClausulaLetras'),
+    hastaTargets: Array.from(document.querySelectorAll('.poliza-hasta'))
+  };
+
+  const camposMonto = [
+    polizaContext.montoContrato,
+    polizaContext.montoConAdicionales,
+    polizaContext.montoAcumulado,
+    polizaContext.saldoAnticipo,
+    polizaContext.certificadoRp
+  ];
+  camposMonto.forEach(campo => {
+    if (campo) {
+      campo.addEventListener('input', actualizarCalculosPoliza);
+      campo.addEventListener('blur', actualizarCalculosPoliza);
+    }
+  });
+
+  if (polizaContext.ultimoFriAprobadoValor) {
+    polizaContext.ultimoFriAprobadoValor.addEventListener('input', actualizarCalculosPoliza);
+    polizaContext.ultimoFriAprobadoValor.addEventListener('blur', actualizarCalculosPoliza);
+  }
+
+  if (polizaContext.ultimoFriAprobadoFecha) {
+    polizaContext.ultimoFriAprobadoFecha.addEventListener('input', actualizarCalculosPoliza);
+    polizaContext.ultimoFriAprobadoFecha.addEventListener('blur', actualizarCalculosPoliza);
+  }
+
+  if (polizaContext.hastaInput) {
+    polizaContext.hastaInput.addEventListener('input', actualizarTextoHastaPoliza);
+    polizaContext.hastaInput.addEventListener('blur', actualizarTextoHastaPoliza);
+  }
+
+  form.addEventListener('reset', () => {
+    setTimeout(() => {
+      actualizarTextoHastaPoliza();
+      actualizarCalculosPoliza();
+    }, 0);
+  });
+
+  const saltosContainer = document.getElementById('saltosContainer');
+  if (saltosContainer) {
+    saltosContainer.addEventListener('input', event => {
+      if (event.target && event.target.classList.contains('salto-acum')) {
+        actualizarCalculosPoliza();
+      }
+    });
+  }
+
+  actualizarTextoHastaPoliza();
+  actualizarCalculosPoliza();
+}
+
+function actualizarTextoHastaPoliza() {
+  if (!polizaContext) return;
+  const valor = obtenerValorHasta();
+  const texto = valor || 'mm/aaaa';
+  polizaContext.hastaTargets.forEach(span => {
+    span.textContent = texto;
+  });
+}
+
+const formateadorMoneda = new Intl.NumberFormat('es-AR', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+});
+
+const formateadorPorcentaje = new Intl.NumberFormat('es-AR', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+});
+
+function actualizarCalculosPoliza() {
+  if (!polizaContext) return;
+  const selector = document.getElementById('tienePoliza');
+  if (selector && selector.value !== 'si') {
+    limpiarResultadosPoliza();
+    return;
+  }
+
+  const montoConAdicionales = parseMonto(obtenerValorCampo(polizaContext.montoConAdicionales));
+  const montoAcumulado = parseMonto(obtenerValorCampo(polizaContext.montoAcumulado));
+  const saldoAnticipo = parseMonto(obtenerValorCampo(polizaContext.saldoAnticipo));
+
+  let saldoNeto = null;
+  if ([montoConAdicionales, montoAcumulado, saldoAnticipo].some(valor => valor !== null)) {
+    saldoNeto = redondearDosDecimales((montoConAdicionales ?? 0) - (montoAcumulado ?? 0) - (saldoAnticipo ?? 0));
+  }
+  if (polizaContext.saldoNeto) {
+    polizaContext.saldoNeto.value = saldoNeto !== null ? formatearMoneda(saldoNeto) : '';
+  }
+
+  const ultimoFri = obtenerUltimoSaltoValor();
+  if (polizaContext.ultimoFriValor) {
+    polizaContext.ultimoFriValor.value = ultimoFri !== null ? formatearPorcentaje(ultimoFri) : '';
+  }
+
+  const ultimoFriAprobado = parsePorcentaje(obtenerValorCampo(polizaContext.ultimoFriAprobadoValor));
+  const incrementoFri = ultimoFri !== null && ultimoFriAprobado !== null
+    ? redondearDosDecimales(ultimoFri - ultimoFriAprobado)
+    : null;
+  if (polizaContext.incrementoFri) {
+    polizaContext.incrementoFri.value = incrementoFri !== null ? formatearPorcentaje(incrementoFri) : '';
+  }
+
+  const baseContratacion = saldoNeto !== null && incrementoFri !== null
+    ? redondearDosDecimales(saldoNeto * (incrementoFri / 100))
+    : null;
+  if (polizaContext.baseContratacion) {
+    polizaContext.baseContratacion.value = baseContratacion !== null ? formatearMoneda(baseContratacion) : '';
+  }
+  if (polizaContext.baseContratacionCopia) {
+    polizaContext.baseContratacionCopia.value = baseContratacion !== null ? formatearMoneda(baseContratacion) : '';
+  }
+
+  const montoGarantizarSaldo = baseContratacion !== null
+    ? redondearDosDecimales(baseContratacion * 0.05)
+    : null;
+  if (polizaContext.montoGarantizarSaldo) {
+    polizaContext.montoGarantizarSaldo.value = montoGarantizarSaldo !== null ? formatearMoneda(montoGarantizarSaldo) : '';
+  }
+
+  const certificadoRp = parseMonto(obtenerValorCampo(polizaContext.certificadoRp));
+  const montoGarantizarRp = certificadoRp !== null
+    ? redondearDosDecimales(certificadoRp * 0.05)
+    : null;
+  if (polizaContext.montoGarantizarRp) {
+    polizaContext.montoGarantizarRp.value = montoGarantizarRp !== null ? formatearMoneda(montoGarantizarRp) : '';
+  }
+
+  let montoTotal = null;
+  if (montoGarantizarSaldo !== null || montoGarantizarRp !== null) {
+    montoTotal = redondearDosDecimales((montoGarantizarSaldo ?? 0) + (montoGarantizarRp ?? 0));
+  }
+  if (polizaContext.montoTotal) {
+    polizaContext.montoTotal.value = montoTotal !== null ? formatearMoneda(montoTotal) : '';
+  }
+  if (polizaContext.montoClausula) {
+    polizaContext.montoClausula.value = montoTotal !== null ? formatearMoneda(montoTotal) : '';
+  }
+  if (polizaContext.montoClausulaLetras) {
+    polizaContext.montoClausulaLetras.value = montoTotal !== null ? numeroALetras(montoTotal) : '';
+  }
+}
+
+function limpiarResultadosPoliza() {
+  if (!polizaContext) return;
+  const campos = [
+    'saldoNeto',
+    'ultimoFriValor',
+    'incrementoFri',
+    'baseContratacion',
+    'baseContratacionCopia',
+    'montoGarantizarSaldo',
+    'montoGarantizarRp',
+    'montoTotal',
+    'montoClausula'
+  ];
+  campos.forEach(nombre => {
+    const campo = polizaContext[nombre];
+    if (campo) campo.value = '';
+  });
+  if (polizaContext.montoClausulaLetras) {
+    polizaContext.montoClausulaLetras.value = '';
+  }
+}
+
+function obtenerValorCampo(campo) {
+  if (!campo) return '';
+  return (campo.value || '').trim();
+}
+
+function parseMonto(valor) {
+  if (!valor) return null;
+  const limpio = valor.replace(/\$/g, '').trim();
+  if (!limpio) return null;
+  const normalizado = normalizarMontoTexto(limpio);
+  const numero = Number(normalizado);
+  if (Number.isNaN(numero)) return null;
+  return numero;
+}
+
+function parsePorcentaje(valor) {
+  if (!valor) return null;
+  const sinSimbolo = valor.replace(/%/g, '').trim();
+  if (!sinSimbolo) return null;
+  const normalizado = normalizarMontoTexto(sinSimbolo);
+  const numero = Number(normalizado);
+  if (Number.isNaN(numero)) return null;
+  return numero;
+}
+
+function formatearMoneda(valor) {
+  if (typeof valor !== 'number' || !Number.isFinite(valor)) return '';
+  return formateadorMoneda.format(valor);
+}
+
+function formatearPorcentaje(valor) {
+  if (typeof valor !== 'number' || !Number.isFinite(valor)) return '';
+  return formateadorPorcentaje.format(valor);
+}
+
+function obtenerUltimoSaltoValor() {
+  const cont = document.getElementById('saltosContainer');
+  if (!cont) return null;
+  const saltos = cont.querySelectorAll('.salto-acum');
+  for (let i = saltos.length - 1; i >= 0; i -= 1) {
+    const valor = parsePorcentaje(obtenerValorCampo(saltos[i]));
+    if (valor !== null) return valor;
+  }
+  return null;
+}
+
+function obtenerValorHasta() {
+  if (!polizaContext || !polizaContext.hastaInput) return '';
+  return (polizaContext.hastaInput.value || '').trim();
+}
+
+function redondearDosDecimales(valor) {
+  if (typeof valor !== 'number' || !Number.isFinite(valor)) return null;
+  return Math.round(valor * 100) / 100;
 }
 
 const ordinalesMasc = [
@@ -231,6 +482,7 @@ const VEINTI = {
   29: 'veintinueve'
 };
 
+let polizaContext = null;
 let empresasCache = null;
 let empresasPromise = null;
 

--- a/redeterminaciones.html
+++ b/redeterminaciones.html
@@ -102,6 +102,10 @@
             <input type="text" id="obraNombre">
           </label>
           <small class="field-hint"><em>Sugerencia: copiar y pegar el nombre del sistema GESOP.</em></small>
+          <label>N° de Expediente
+            <input type="text" id="obraExpediente" placeholder="nnnn-M-202X" pattern="\d{4}-M-202\d" inputmode="text">
+          </label>
+          <small class="field-hint"><em>Ejemplo de formato: 1234-M-2023.</em></small>
           <div class="aprobada-por-row">
             <div class="aprobada-por-field">
               <label>Aprobada por
@@ -192,7 +196,117 @@
               <option value="si">Sí</option>
             </select>
           </label>
-          <div id="polizaForm" class="oculto"></div>
+          <div id="polizaForm" class="oculto">
+            <div class="poliza-grid">
+              <label>Monto del contrato
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaMontoContrato" inputmode="decimal" pattern="\d+(?:[.,]\d{1,2})?" placeholder="0000000,00">
+                </div>
+              </label>
+              <label>Monto con adicionales
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaMontoConAdicionales" inputmode="decimal" pattern="\d+(?:[.,]\d{1,2})?" placeholder="0000000,00">
+                </div>
+              </label>
+              <label>Monto Obra acumulada a <span class="poliza-hasta" data-poliza-hasta="acumulada">mm/aaaa</span>
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaMontoObraAcumulada" inputmode="decimal" pattern="\d+(?:[.,]\d{1,2})?" placeholder="0000000,00">
+                </div>
+                <small class="field-hint"><em>El monto lo encontrás en el último certificado de obra a redeterminar por el concepto de "A)".</em></small>
+              </label>
+              <label>Saldo de Anticipo Financiero a <span class="poliza-hasta" data-poliza-hasta="anticipo">mm/aaaa</span>
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaSaldoAnticipo" inputmode="decimal" pattern="\d+(?:[.,]\d{1,2})?" placeholder="0000000,00">
+                </div>
+                <small class="field-hint"><em>El monto lo encontrás en el último certificado de obra a redeterminar por el concepto de "Saldo Anticipo Financiero (informativo) $".</em></small>
+              </label>
+              <label>SALDO DE OBRA NETO DE ANTICIPO FINANCIERO AL <span class="poliza-hasta" data-poliza-hasta="saldo-neto">mm/aaaa</span>
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaSaldoNeto" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                </div>
+              </label>
+              <label>ÚLTIMO FRI A <span class="poliza-hasta" data-poliza-hasta="ultimo-fri">mm/aaaa</span>
+                <div class="salto-porcentaje">
+                  <input type="text" id="polizaUltimoFriValor" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <span class="porcentaje-signo" aria-hidden="true">%</span>
+                </div>
+                <small class="field-hint"><em>Se toma el último valor de los saltos cargados.</em></small>
+              </label>
+              <div class="poliza-ultimo-aprobado">
+                <span class="poliza-ultimo-aprobado-titulo">ÚLTIMO FRI APROBADO A</span>
+                <div class="poliza-ultimo-aprobado-campos">
+                  <label>Fecha
+                    <input type="text" id="polizaUltimoFriAprobadoFecha" placeholder="mm/aaaa" pattern="\d{2}/\d{4}">
+                  </label>
+                  <label>Porcentaje
+                    <div class="salto-porcentaje">
+                      <input type="text" id="polizaUltimoFriAprobadoValor" placeholder="NN,NN" inputmode="decimal" pattern="\d+(?:[.,]\d{1,2})?">
+                      <span class="porcentaje-signo" aria-hidden="true">%</span>
+                    </div>
+                  </label>
+                </div>
+              </div>
+              <label>Incremento de FRI
+                <div class="salto-porcentaje">
+                  <input type="text" id="polizaIncrementoFri" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <span class="porcentaje-signo" aria-hidden="true">%</span>
+                </div>
+              </label>
+              <label>BASE PARA CONTRATACIÓN DE PÓLIZA
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaBaseContratacion" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                </div>
+              </label>
+              <label>BASE PARA CONTRATACIÓN DE PÓLIZA
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaBaseContratacionCopia" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                </div>
+              </label>
+              <label>MONTO A GARANTIZAR POR SALDO DE OBRA
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaMontoGarantizarSaldoObra" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                </div>
+              </label>
+              <label>CERTIFICADO DE REDETERMINACIÓN DE PRECIOS MODELO AL <span class="poliza-hasta" data-poliza-hasta="certificado">mm/aaaa</span>
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaCertificadoRp" inputmode="decimal" pattern="\d+(?:[.,]\d{1,2})?" placeholder="0000000,00">
+                </div>
+                <small class="field-hint"><em>El monto lo encontrás en el certificado de Redeterminación, en el total de la columna "Diferencia A Pagar".</em></small>
+              </label>
+              <label>MONTO A GARANTIZAR POR R.P
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaMontoGarantizarRp" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                </div>
+              </label>
+              <label>MONTO TOTAL A GARANTIZAR
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaMontoTotalGarantizar" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                </div>
+              </label>
+              <div class="poliza-total">
+                <label>La póliza de ejecución de contrato que va en la cláusula SEXTA del Acta de Adhesión es de
+                  <div class="monto-input">
+                    <span class="peso-signo" aria-hidden="true">$</span>
+                    <input type="text" id="polizaMontoClausula" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  </div>
+                </label>
+                <label>Monto en letras
+                  <input type="text" id="polizaMontoClausulaLetras" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                </label>
+              </div>
+            </div>
+          </div>
         </fieldset>
 
         <div class="acciones">

--- a/styles.css
+++ b/styles.css
@@ -606,6 +606,49 @@ label {
   color: #4d6fa6;
 }
 
+#polizaForm .poliza-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.poliza-hasta {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.poliza-ultimo-aprobado {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(77, 111, 166, 0.3);
+  border-radius: 8px;
+  background: rgba(153, 198, 255, 0.15);
+}
+
+.poliza-ultimo-aprobado-titulo {
+  display: block;
+  font-weight: 600;
+}
+
+.poliza-ultimo-aprobado-campos {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-top: 0.75rem;
+}
+
+.poliza-ultimo-aprobado-campos label {
+  margin-top: 0;
+}
+
+.poliza-total {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .aprobada-por-row {
   display: grid;
   gap: 0.75rem;


### PR DESCRIPTION
## Summary
- add an expediente input to the "Datos de la obra" section
- expand the póliza section with all requested inputs, computed totals, and hints tied to the "Hasta" date
- update styling and client-side logic to calculate intermediate values, totals, and amounts in words for the póliza summary

## Testing
- not run (no automated test suite provided)


------
https://chatgpt.com/codex/tasks/task_e_68d9fe33f754832e8168c581d4ee4fe4