### PR TITLE
Ajustes de interfaz para el cálculo de póliza

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const polizaSel = document.getElementById('tienePoliza');
-  if (polizaSel) polizaSel.addEventListener('change', e => togglePoliza(e.target.value));
+  if (polizaSel) {
+    polizaSel.addEventListener('change', e => togglePoliza(e.target.value));
+    togglePoliza(polizaSel.value);
+  }
 
   const aprobadaPorSel = document.getElementById('aprobadaPor');
   if (aprobadaPorSel) {
@@ -85,10 +88,16 @@ function toggleEmpresaOtro(val) {
 }
 
 function togglePoliza(val) {
-  const form = document.getElementById('polizaForm');
-  if (!form) return;
-  if (val === 'si') form.classList.remove('oculto');
-  else form.classList.add('oculto');
+  const panel = document.getElementById('polizaForm');
+  const wrapper = document.querySelector('.form-wrapper');
+  if (!panel || !wrapper) return;
+  if (val === 'si') {
+    wrapper.classList.add('poliza-activa');
+    panel.setAttribute('aria-hidden', 'false');
+  } else {
+    wrapper.classList.remove('poliza-activa');
+    panel.setAttribute('aria-hidden', 'true');
+  }
   actualizarCalculosPoliza();
 }
 

--- a/redeterminaciones.html
+++ b/redeterminaciones.html
@@ -196,7 +196,7 @@
               <option value="si">Sí</option>
             </select>
           </label>
-          <div id="polizaForm" class="oculto">
+          <div id="polizaForm" class="poliza-panel" aria-hidden="true">
             <div class="poliza-grid">
               <label>Monto del contrato
                 <div class="monto-input">
@@ -227,12 +227,12 @@
               <label>SALDO DE OBRA NETO DE ANTICIPO FINANCIERO AL <span class="poliza-hasta" data-poliza-hasta="saldo-neto">mm/aaaa</span>
                 <div class="monto-input">
                   <span class="peso-signo" aria-hidden="true">$</span>
-                  <input type="text" id="polizaSaldoNeto" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <input type="text" id="polizaSaldoNeto" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                 </div>
               </label>
               <label>ÚLTIMO FRI A <span class="poliza-hasta" data-poliza-hasta="ultimo-fri">mm/aaaa</span>
                 <div class="salto-porcentaje">
-                  <input type="text" id="polizaUltimoFriValor" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <input type="text" id="polizaUltimoFriValor" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                   <span class="porcentaje-signo" aria-hidden="true">%</span>
                 </div>
                 <small class="field-hint"><em>Se toma el último valor de los saltos cargados.</em></small>
@@ -253,26 +253,26 @@
               </div>
               <label>Incremento de FRI
                 <div class="salto-porcentaje">
-                  <input type="text" id="polizaIncrementoFri" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <input type="text" id="polizaIncrementoFri" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                   <span class="porcentaje-signo" aria-hidden="true">%</span>
                 </div>
               </label>
               <label>BASE PARA CONTRATACIÓN DE PÓLIZA
                 <div class="monto-input">
                   <span class="peso-signo" aria-hidden="true">$</span>
-                  <input type="text" id="polizaBaseContratacion" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <input type="text" id="polizaBaseContratacion" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                 </div>
               </label>
               <label>BASE PARA CONTRATACIÓN DE PÓLIZA
                 <div class="monto-input">
                   <span class="peso-signo" aria-hidden="true">$</span>
-                  <input type="text" id="polizaBaseContratacionCopia" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <input type="text" id="polizaBaseContratacionCopia" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                 </div>
               </label>
               <label>MONTO A GARANTIZAR POR SALDO DE OBRA
                 <div class="monto-input">
                   <span class="peso-signo" aria-hidden="true">$</span>
-                  <input type="text" id="polizaMontoGarantizarSaldoObra" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <input type="text" id="polizaMontoGarantizarSaldoObra" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                 </div>
               </label>
               <label>CERTIFICADO DE REDETERMINACIÓN DE PRECIOS MODELO AL <span class="poliza-hasta" data-poliza-hasta="certificado">mm/aaaa</span>
@@ -285,20 +285,20 @@
               <label>MONTO A GARANTIZAR POR R.P
                 <div class="monto-input">
                   <span class="peso-signo" aria-hidden="true">$</span>
-                  <input type="text" id="polizaMontoGarantizarRp" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <input type="text" id="polizaMontoGarantizarRp" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                 </div>
               </label>
               <label>MONTO TOTAL A GARANTIZAR
                 <div class="monto-input">
                   <span class="peso-signo" aria-hidden="true">$</span>
-                  <input type="text" id="polizaMontoTotalGarantizar" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                  <input type="text" id="polizaMontoTotalGarantizar" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                 </div>
               </label>
               <div class="poliza-total">
                 <label>La póliza de ejecución de contrato que va en la cláusula SEXTA del Acta de Adhesión es de
                   <div class="monto-input">
                     <span class="peso-signo" aria-hidden="true">$</span>
-                    <input type="text" id="polizaMontoClausula" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                    <input type="text" id="polizaMontoClausula" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                   </div>
                 </label>
                 <label>Monto en letras

--- a/styles.css
+++ b/styles.css
@@ -468,10 +468,63 @@ body.dark .speech-bubble {
   position: relative;
   max-width: 600px;
   margin: 2rem auto;
+  transition: max-width 0.4s ease;
 }
 
 .form-wrapper .container {
   margin: 0;
+  transition: transform 0.4s ease, opacity 0.4s ease;
+}
+
+.form-wrapper.poliza-activa {
+  max-width: 1100px;
+}
+
+.form-wrapper.poliza-activa .container {
+  transform: translateX(-240px);
+  opacity: 0.35;
+}
+
+.poliza-panel {
+  position: fixed;
+  top: 110px;
+  right: 2rem;
+  width: min(420px, calc(100% - 4rem));
+  max-height: calc(100vh - 140px);
+  overflow-y: auto;
+  background: var(--card-bg);
+  border-radius: var(--card-radius);
+  box-shadow: 0 18px 40px rgba(12, 79, 183, 0.25);
+  padding: 1.5rem;
+  transform: translateX(120%);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.4s ease, opacity 0.4s ease;
+  z-index: 900;
+}
+
+.form-wrapper.poliza-activa .poliza-panel {
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (max-width: 900px) {
+  .form-wrapper.poliza-activa {
+    max-width: 600px;
+  }
+
+  .form-wrapper.poliza-activa .container {
+    transform: none;
+    opacity: 1;
+  }
+
+  .poliza-panel {
+    right: 1rem;
+    left: 1rem;
+    width: auto;
+    max-height: calc(100vh - 130px);
+  }
 }
 
 .calc-mascot {
@@ -1249,6 +1302,12 @@ body.dark-mode img {
   align-items: center;
   gap: 1rem;
   flex-wrap: wrap;
+}
+
+#generarSaltos {
+  padding: 0.45rem 0.9rem;
+  white-space: nowrap;
+  font-size: 0.9rem;
 }
 
 .saltos-container {


### PR DESCRIPTION
## Summary
- Añadí un panel lateral fijo para los datos de póliza y animé el formulario principal para que se deslice con opacidad al habilitar el cálculo.
- Apliqué el estilo de "Monto en letras" a todos los campos calculados de la póliza para enfatizar que no son editables.
- Ajusté el tamaño del botón "Generar filas" para alinearlo con el campo de cantidad de saltos.

## Testing
- Manualmente cargué `redeterminaciones.html` y verifiqué la interacción del selector de póliza.

------
https://chatgpt.com/codex/tasks/task_e_68dac6ad71d4832e9f0a3b7e7cf31e3f