### PR TITLE
Fix póliza panel visibility on redeterminaciones page

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -473,15 +473,15 @@ body.dark .speech-bubble {
 
 .form-wrapper .container {
   margin: 0;
-  transition: transform 0.4s ease, opacity 0.4s ease;
+  transition: opacity 0.4s ease;
 }
 
 .form-wrapper.poliza-activa {
   max-width: 1100px;
+  padding-right: 460px;
 }
 
 .form-wrapper.poliza-activa .container {
-  transform: translateX(-240px);
   opacity: 0.35;
 }
 
@@ -512,10 +512,10 @@ body.dark .speech-bubble {
 @media (max-width: 900px) {
   .form-wrapper.poliza-activa {
     max-width: 600px;
+    padding-right: 0;
   }
 
   .form-wrapper.poliza-activa .container {
-    transform: none;
     opacity: 1;
   }
 
@@ -565,7 +565,7 @@ select:focus-visible {
 
 .form-container.loaded {
   opacity: 1;
-  transform: scale(1);
+  transform: none;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- adjust the redeterminaciones layout so the póliza panel is no longer translated outside the viewport
- remove the transform on the form container once it has loaded to keep the panel positioned correctly

## Testing
- Manual verification of "¿Calcular póliza?" toggle in redeterminaciones.html

------
https://chatgpt.com/codex/tasks/task_e_68db110e1230832e932e93c5ef6fdea1