### PR TITLE
Adjust póliza panel layout for clarity

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -468,62 +468,67 @@ body.dark .speech-bubble {
   position: relative;
   max-width: 600px;
   margin: 2rem auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 1rem;
   transition: max-width 0.4s ease;
 }
 
 .form-wrapper .container {
   margin: 0;
-  transition: opacity 0.4s ease;
 }
 
 .form-wrapper.poliza-activa {
   max-width: 1100px;
-  padding-right: 460px;
-}
-
-.form-wrapper.poliza-activa .container {
-  opacity: 0.35;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
 }
 
 .poliza-panel {
-  position: fixed;
+  position: sticky;
   top: 110px;
-  right: 2rem;
-  width: min(420px, calc(100% - 4rem));
+  width: 100%;
   max-height: calc(100vh - 140px);
   overflow-y: auto;
   background: var(--card-bg);
   border-radius: var(--card-radius);
   box-shadow: 0 18px 40px rgba(12, 79, 183, 0.25);
   padding: 1.5rem;
-  transform: translateX(120%);
   opacity: 0;
+  transform: translateY(16px);
   pointer-events: none;
   transition: transform 0.4s ease, opacity 0.4s ease;
-  z-index: 900;
+  z-index: 1;
 }
 
 .form-wrapper.poliza-activa .poliza-panel {
-  transform: translateX(0);
   opacity: 1;
+  transform: translateY(0);
   pointer-events: auto;
 }
 
+@media (max-width: 1100px) {
+  .form-wrapper.poliza-activa {
+    max-width: min(100%, 900px);
+  }
+}
+
 @media (max-width: 900px) {
+  .form-wrapper,
   .form-wrapper.poliza-activa {
     max-width: 600px;
-    padding-right: 0;
-  }
-
-  .form-wrapper.poliza-activa .container {
-    opacity: 1;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .poliza-panel {
-    right: 1rem;
-    left: 1rem;
-    width: auto;
-    max-height: calc(100vh - 130px);
+    position: relative;
+    top: auto;
+    max-height: none;
+    transform: translateY(12px);
+  }
+
+  .form-wrapper.poliza-activa .poliza-panel {
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
## Summary
- display the póliza panel alongside the main form instead of overlaying it
- remove the opacity fade when the póliza toggle is active to keep the form readable
- make the panel responsive with sticky positioning on desktop and stacked layout on mobile

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db16fec314832ea54660f9fac87ff0