### PR TITLE
Registrar solicitudes de redeterminación en Google Sheets

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const formContainer = document.querySelector('.form-container');
   if (formContainer) formContainer.classList.add('loaded');
 
+  const form = document.getElementById('formAsistente');
+  if (form) form.addEventListener('submit', manejarEnvioSolicitud);
+
   const genSaltosBtn = document.getElementById('generarSaltos');
   if (genSaltosBtn) genSaltosBtn.addEventListener('click', generarSaltos);
 
@@ -62,6 +65,7 @@ function limpiarFormulario() {
   const cont = document.getElementById('saltosContainer');
   if (form) form.reset();
   if (cont) cont.innerHTML = '';
+  ocultarEstadoSolicitud();
   const empresa = document.getElementById('empresa');
   if (empresa) toggleEmpresaOtro(empresa.value);
   limpiarCamposEmpresa();
@@ -120,6 +124,8 @@ function inicializarPoliza() {
     montoGarantizarRp: document.getElementById('polizaMontoGarantizarRp'),
     montoTotal: document.getElementById('polizaMontoTotalGarantizar'),
     montoClausulaLetras: document.getElementById('polizaMontoClausulaLetras'),
+    tipoPoliza: document.getElementById('polizaQueCorresponde'),
+    montoPoliza: document.getElementById('polizaMontoPoliza'),
     hastaTargets: Array.from(document.querySelectorAll('.poliza-hasta')),
     calcularRadios: Array.from(document.querySelectorAll('input[name="calcularPoliza"]')),
     errorContenedor: document.getElementById('polizaError'),
@@ -382,6 +388,9 @@ function actualizarCalculosPoliza() {
   if (polizaContext.montoTotal) {
     polizaContext.montoTotal.value = montoTotal !== null ? formatearMoneda(montoTotal) : '';
   }
+  if (polizaContext.montoPoliza) {
+    polizaContext.montoPoliza.value = montoTotal !== null ? formatearMoneda(montoTotal) : '';
+  }
   if (polizaContext.montoClausulaLetras) {
     polizaContext.montoClausulaLetras.value = montoTotal !== null ? numeroALetras(montoTotal) : '';
   }
@@ -401,7 +410,8 @@ function limpiarResultadosPoliza() {
     'baseContratacion',
     'montoGarantizarSaldo',
     'montoGarantizarRp',
-    'montoTotal'
+    'montoTotal',
+    'montoPoliza'
   ];
   campos.forEach(nombre => {
     const campo = polizaContext[nombre];
@@ -421,7 +431,8 @@ function limpiarValoresBasePoliza() {
     polizaContext.saldoAnticipo,
     polizaContext.ultimoFriAprobadoFecha,
     polizaContext.ultimoFriAprobadoValor,
-    polizaContext.certificadoRp
+    polizaContext.certificadoRp,
+    polizaContext.tipoPoliza
   ];
   campos.forEach(campo => {
     if (campo) campo.value = '';
@@ -680,6 +691,145 @@ function inicializarMontoRedeterminacion() {
     });
   }
   actualizarMonto();
+}
+
+async function manejarEnvioSolicitud(event) {
+  event.preventDefault();
+  const submitBtn = document.getElementById('enviarSolicitud');
+  const originalText = submitBtn ? submitBtn.textContent : '';
+  if (submitBtn) {
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Enviando…';
+  }
+  ocultarEstadoSolicitud();
+  try {
+    const payload = recolectarDatosFormulario();
+    const respuesta = await fetch('/api/redeterminaciones', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!respuesta.ok) {
+      const detalle = await respuesta.json().catch(() => ({}));
+      const mensaje = detalle && detalle.error ? detalle.error : 'Error al registrar la solicitud';
+      throw new Error(mensaje);
+    }
+    mostrarEstadoSolicitud('success', '✅ Solicitud registrada correctamente. Los documentos se generarán automáticamente en breve.');
+  } catch (error) {
+    console.error('Error enviando la solicitud de redeterminación:', error);
+    mostrarEstadoSolicitud('error', '❌ Hubo un error al registrar la solicitud. Intente nuevamente o verifique la conexión con la planilla.');
+  } finally {
+    if (submitBtn) {
+      submitBtn.disabled = false;
+      submitBtn.textContent = originalText;
+    }
+  }
+}
+
+function recolectarDatosFormulario() {
+  const representanteTipo = obtenerValorPorId('repTipo');
+  const representanteNombre = obtenerValorPorId('repNombreDni');
+  const representante = [representanteTipo, representanteNombre].filter(Boolean).join(' - ');
+  const ultimoFriAprobadoFecha = obtenerValorPorId('polizaUltimoFriAprobadoFecha');
+  const ultimoFriAprobadoValor = obtenerValorPorId('polizaUltimoFriAprobadoValor');
+  return {
+    expediente: obtenerValorPorId('obraExpediente'),
+    tipoRedeterminacion: obtenerValorPorId('tipoRedeterminacion'),
+    empresa: obtenerEmpresaSeleccionada(),
+    representante,
+    domicilio: obtenerValorPorId('repDomicilio'),
+    obraNombre: obtenerValorPorId('obraNombre'),
+    aprobadaPor: obtenerTextoSeleccion('aprobadaPor'),
+    numeroAdjudicacion: obtenerValorPorId('aprobadaNumero'),
+    periodoDesde: obtenerValorPorId('cambiosDesde'),
+    periodoHasta: obtenerValorPorId('cambiosHasta'),
+    numeroRedeterminacion: obtenerTextoSeleccion('nRedet'),
+    montoRedeterminacion: obtenerValorPorId('montoRedeterminacion'),
+    montoRedeterminacionLetras: obtenerValorPorId('montoRedeterminacionLetras'),
+    montoContrato: obtenerValorPorId('polizaMontoContrato'),
+    montoConAdicionales: obtenerValorPorId('polizaMontoConAdicionales'),
+    montoObraAcumulada: obtenerValorPorId('polizaMontoObraAcumulada'),
+    saldoAnticipo: obtenerValorPorId('polizaSaldoAnticipo'),
+    ultimoFri: agregarSimboloPorcentaje(obtenerValorPorId('polizaUltimoFriValor')),
+    ultimoFriAprobado: combinarUltimoFriAprobado(ultimoFriAprobadoFecha, ultimoFriAprobadoValor),
+    incrementoFri: agregarSimboloPorcentaje(obtenerValorPorId('polizaIncrementoFri')),
+    baseContratacion: obtenerValorPorId('polizaBaseContratacion'),
+    montoGarantizarSaldoObra: obtenerValorPorId('polizaMontoGarantizarSaldoObra'),
+    montoGarantizarRedeterminacion: obtenerValorPorId('polizaMontoGarantizarRp'),
+    montoTotalGarantizar: obtenerValorPorId('polizaMontoTotalGarantizar'),
+    polizaQueCorresponde: obtenerValorPorId('polizaQueCorresponde'),
+    montoPoliza: obtenerValorPorId('polizaMontoPoliza'),
+    montoPolizaLetras: obtenerValorPorId('polizaMontoClausulaLetras')
+  };
+}
+
+function obtenerValorPorId(id) {
+  const elemento = document.getElementById(id);
+  if (!elemento) return '';
+  return (elemento.value || '').trim();
+}
+
+function obtenerEmpresaSeleccionada() {
+  const select = document.getElementById('empresa');
+  if (!select) return '';
+  const valor = select.value;
+  if (valor === 'OTRO') {
+    return obtenerValorPorId('empresaOtro');
+  }
+  if (!valor) return '';
+  const opcion = select.options[select.selectedIndex];
+  const texto = opcion ? opcion.text : valor;
+  return texto.trim();
+}
+
+function obtenerTextoSeleccion(id) {
+  const select = document.getElementById(id);
+  if (!select) return '';
+  const indice = select.selectedIndex;
+  if (indice < 0) return '';
+  const opcion = select.options[indice];
+  return opcion ? (opcion.text || '').trim() : '';
+}
+
+function agregarSimboloPorcentaje(valor) {
+  if (!valor) return '';
+  const texto = valor.trim();
+  if (!texto) return '';
+  return /%$/.test(texto) ? texto : `${texto}%`;
+}
+
+function combinarUltimoFriAprobado(fecha, valor) {
+  const fechaLimpia = (fecha || '').trim();
+  const porcentaje = agregarSimboloPorcentaje(valor || '');
+  if (fechaLimpia && porcentaje) return `${fechaLimpia} - ${porcentaje}`;
+  if (fechaLimpia) return fechaLimpia;
+  return porcentaje;
+}
+
+function mostrarEstadoSolicitud(tipo, mensaje) {
+  const contenedor = document.getElementById('formStatus');
+  if (!contenedor) return;
+  contenedor.classList.remove('oculto', 'form-status--success', 'form-status--error');
+  const textoEl = contenedor.querySelector('.form-status-text');
+  if (textoEl) {
+    textoEl.textContent = mensaje;
+  }
+  if (tipo === 'success') {
+    contenedor.classList.add('form-status--success');
+  } else if (tipo === 'error') {
+    contenedor.classList.add('form-status--error');
+  }
+}
+
+function ocultarEstadoSolicitud() {
+  const contenedor = document.getElementById('formStatus');
+  if (!contenedor) return;
+  contenedor.classList.add('oculto');
+  contenedor.classList.remove('form-status--success', 'form-status--error');
+  const textoEl = contenedor.querySelector('.form-status-text');
+  if (textoEl) {
+    textoEl.textContent = '';
+  }
 }
 
 function normalizarMontoTexto(valor) {

--- a/redeterminaciones.html
+++ b/redeterminaciones.html
@@ -129,6 +129,9 @@
 
         <fieldset>
           <legend>Redeterminación</legend>
+          <label>Tipo de redeterminación
+            <input type="text" id="tipoRedeterminacion" placeholder="Ej.: Licitación Pública, Contratación Directa, etc.">
+          </label>
           <label>Cambios registrados desde
             <input type="text" id="cambiosDesde" placeholder="dd/mm/aaaa" pattern="\d{2}/\d{2}/\d{4}">
           </label>
@@ -311,6 +314,17 @@
                   <input type="text" id="polizaMontoTotalGarantizar" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
                 </div>
               </div>
+              <div class="form-field">
+                <label for="polizaQueCorresponde">Póliza que corresponde</label>
+                <input type="text" id="polizaQueCorresponde" placeholder="Ej.: Garantía de cumplimiento, Fondo de reparo, etc.">
+              </div>
+              <div class="form-field">
+                <label for="polizaMontoPoliza">Monto de la póliza</label>
+                <div class="monto-input">
+                  <span class="peso-signo" aria-hidden="true">$</span>
+                  <input type="text" id="polizaMontoPoliza" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
+                </div>
+              </div>
               <div class="poliza-total">
                 <label for="polizaMontoClausulaLetras">Monto en letras de la póliza</label>
                 <input type="text" id="polizaMontoClausulaLetras" class="monto-letras" readonly aria-readonly="true" placeholder="Se completa automáticamente">
@@ -321,6 +335,11 @@
 
         <div class="acciones">
           <button type="reset" id="limpiarFormulario">Limpiar</button>
+          <button type="submit" id="enviarSolicitud" class="btn-enviar">ENVIAR SOLICITUD</button>
+        </div>
+        <div id="formStatus" class="form-status oculto" role="status" aria-live="polite">
+          <img src="Certy_celular.png" alt="Certy" class="form-status-logo" width="72" height="90">
+          <p class="form-status-text"></p>
         </div>
       </form>
     </div>

--- a/server.js
+++ b/server.js
@@ -2,10 +2,17 @@ const express = require('express');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
 
 const app = express();
 const uploadDir = path.join(__dirname, 'uploads');
 app.use(express.json({ limit: '5mb' }));
+
+const SHEET_ID = '1oGUQY-kEEj5q6LLHdvVOyNZSlTonp0vUpg0hLrrZviM';
+const SHEET_TAB = 'Respuestas';
+const SHEETS_SCOPE = 'https://www.googleapis.com/auth/spreadsheets';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const SHEETS_BASE_URL = 'https://sheets.googleapis.com/v4/spreadsheets';
 
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir);
@@ -17,6 +24,151 @@ const storage = multer.diskStorage({
 });
 
 const upload = multer({ storage });
+
+async function registrarFilaRedeterminacion(datos) {
+  const token = await obtenerTokenSheets();
+  const fila = construirFilaRedeterminacion(datos);
+  const rango = encodeURIComponent(`${SHEET_TAB}!A:AB`);
+  const url = `${SHEETS_BASE_URL}/${SHEET_ID}/values/${rango}:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS`;
+  const respuesta = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({ values: [fila] })
+  });
+  if (!respuesta.ok) {
+    const texto = await respuesta.text();
+    throw new Error(`Error al actualizar la planilla: ${respuesta.status} ${texto}`);
+  }
+}
+
+let cachedToken = null;
+let tokenExpiration = 0;
+
+async function obtenerTokenSheets() {
+  const ahora = Math.floor(Date.now() / 1000);
+  if (cachedToken && ahora < tokenExpiration - 60) {
+    return cachedToken;
+  }
+  const email = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
+  const privateKey = process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY;
+  if (!email || !privateKey) {
+    throw new Error('Credenciales de Google Sheets no configuradas');
+  }
+  const jwt = crearJwtDeServicio(email, privateKey, ahora);
+  const params = new URLSearchParams();
+  params.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+  params.append('assertion', jwt);
+
+  const respuesta = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString()
+  });
+  if (!respuesta.ok) {
+    const texto = await respuesta.text();
+    throw new Error(`Error obteniendo token de Google: ${respuesta.status} ${texto}`);
+  }
+  const cuerpo = await respuesta.json();
+  cachedToken = cuerpo.access_token;
+  tokenExpiration = ahora + (cuerpo.expires_in || 3600);
+  return cachedToken;
+}
+
+function crearJwtDeServicio(email, privateKey, issuedAt) {
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const payload = {
+    iss: email,
+    scope: SHEETS_SCOPE,
+    aud: GOOGLE_TOKEN_URL,
+    iat: issuedAt,
+    exp: issuedAt + 3600
+  };
+  const segmentos = [
+    base64UrlEncode(Buffer.from(JSON.stringify(header))),
+    base64UrlEncode(Buffer.from(JSON.stringify(payload)))
+  ];
+  const signingInput = segmentos.join('.');
+  const signature = firmarJwtSegmentos(signingInput, privateKey);
+  return `${signingInput}.${signature}`;
+}
+
+function firmarJwtSegmentos(input, privateKey) {
+  const signer = crypto.createSign('RSA-SHA256');
+  signer.update(input);
+  signer.end();
+  const key = privateKey.replace(/\\n/g, '\n');
+  const signature = signer.sign(key);
+  return base64UrlEncode(signature);
+}
+
+function base64UrlEncode(buffer) {
+  return buffer.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function construirFilaRedeterminacion(datos) {
+  const timestamp = obtenerMarcaTemporal();
+  const fila = [
+    timestamp,
+    datos.expediente,
+    datos.tipoRedeterminacion,
+    datos.empresa,
+    datos.representante,
+    datos.domicilio,
+    datos.obraNombre,
+    datos.aprobadaPor,
+    datos.numeroAdjudicacion,
+    datos.periodoDesde,
+    datos.periodoHasta,
+    datos.numeroRedeterminacion,
+    datos.montoRedeterminacion,
+    datos.montoRedeterminacionLetras,
+    datos.montoContrato,
+    datos.montoConAdicionales,
+    datos.montoObraAcumulada,
+    datos.saldoAnticipo,
+    datos.ultimoFri,
+    datos.ultimoFriAprobado,
+    datos.incrementoFri,
+    datos.baseContratacion,
+    datos.montoGarantizarSaldoObra,
+    datos.montoGarantizarRedeterminacion,
+    datos.montoTotalGarantizar,
+    datos.polizaQueCorresponde,
+    datos.montoPoliza,
+    datos.montoPolizaLetras
+  ];
+  return fila.map(normalizarValorCelda);
+}
+
+function normalizarValorCelda(valor) {
+  if (valor === null || valor === undefined) return '';
+  if (typeof valor === 'string') return valor.trim();
+  return String(valor);
+}
+
+function obtenerMarcaTemporal() {
+  const formateador = new Intl.DateTimeFormat('es-AR', {
+    dateStyle: 'short',
+    timeStyle: 'medium',
+    timeZone: 'America/Argentina/Buenos_Aires'
+  });
+  return formateador.format(new Date());
+}
+
+function validarDatosRedeterminacion(datos) {
+  const requeridos = ['expediente', 'empresa', 'obraNombre'];
+  const faltantes = requeridos.filter(campo => !tieneValor(datos[campo]));
+  return faltantes;
+}
+
+function tieneValor(valor) {
+  if (valor === null || valor === undefined) return false;
+  if (typeof valor === 'string') return valor.trim() !== '';
+  return true;
+}
 
 app.post('/pdf', upload.single('file'), (req, res) => {
   try {
@@ -73,6 +225,21 @@ app.post('/generate-pdf', (req, res) => {
   } catch (err) {
     console.error('Error generating PDF:', err);
     res.status(500).json({ error: 'Error generando el PDF' });
+  }
+});
+
+app.post('/api/redeterminaciones', async (req, res) => {
+  try {
+    const datos = req.body || {};
+    const faltantes = validarDatosRedeterminacion(datos);
+    if (faltantes.length > 0) {
+      return res.status(400).json({ error: `Faltan datos obligatorios: ${faltantes.join(', ')}` });
+    }
+    await registrarFilaRedeterminacion(datos);
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Error registrando solicitud de redeterminación:', err);
+    res.status(500).json({ error: 'Error al registrar la solicitud' });
   }
 });
 

--- a/styles.css
+++ b/styles.css
@@ -584,6 +584,92 @@ label {
   flex: 1;
 }
 
+.acciones {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+#limpiarFormulario {
+  background: #e0e7ff;
+  color: var(--color-primary);
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+#limpiarFormulario:hover {
+  background: #c7d2fe;
+  transform: translateY(-1px);
+}
+
+.btn-enviar {
+  background: #2e7d32;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.btn-enviar:hover {
+  background: #1b5e20;
+  transform: translateY(-1px);
+}
+
+.btn-enviar:disabled {
+  background: #9e9e9e;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.form-status {
+  margin-top: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border: 1px solid transparent;
+  background: #f5f7fb;
+  color: var(--color-text);
+}
+
+.form-status-logo {
+  display: none;
+  width: 72px;
+  height: auto;
+}
+
+.form-status-text {
+  margin: 0;
+  font-weight: 600;
+}
+
+.form-status--success {
+  background: #e6f4ea;
+  border-color: #badbcc;
+  color: #0f5132;
+}
+
+.form-status--success .form-status-logo {
+  display: block;
+}
+
+.form-status--error {
+  background: #fdecea;
+  border-color: #f5c2c7;
+  color: #842029;
+}
+
 .peso-signo {
   font-weight: 600;
   color: var(--color-primary);


### PR DESCRIPTION
## Summary
- agregar el campo de tipo de redeterminación, el botón de envío y un panel de estado para registrar las solicitudes completas
- aplicar estilos al área de acciones y a los mensajes de confirmación o error mostrados tras enviar la solicitud
- enviar los datos del formulario a un nuevo endpoint que agrega la fila en Google Sheets mediante autenticación JWT del servicio

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68db2595c2cc832ea57034dbd23b86b8